### PR TITLE
Add UBERON-MeSH mappings

### DIFF
--- a/scripts/generate_uberon_mesh_mappings.py
+++ b/scripts/generate_uberon_mesh_mappings.py
@@ -1,40 +1,37 @@
 import gilda
 import obonet
 from indra.databases import mesh_client
-from biomappings.resources import PredictionTuple, \
-    append_prediction_tuples
+from biomappings.resources import PredictionTuple, append_prediction_tuples
 
-g = obonet.read_obo('/Users/ben/src/uberon/src/ontology/uberon-edit.obo')
+g = obonet.read_obo("/Users/ben/src/uberon/src/ontology/uberon-edit.obo")
 
 mappings = {}
 for node, data in g.nodes(data=True):
-    if not node.startswith('UBERON'):
+    if not node.startswith("UBERON"):
         continue
-    mesh_refs = [xref for xref in data.get('xref', [])
-                 if xref.startswith('MESH')]
+    mesh_refs = [xref for xref in data.get("xref", []) if xref.startswith("MESH")]
     if mesh_refs:
         continue
-    matches = gilda.ground(data['name'])
-    if matches and matches[0].term.db == 'MESH':
+    matches = gilda.ground(data["name"])
+    if matches and matches[0].term.db == "MESH":
         mappings[node] = matches[0].term.id
 
-print('Found %d UBERON->MESH mappings.' % len(mappings))
+print("Found %d UBERON->MESH mappings." % len(mappings))
 
 predictions = []
 for uberon_id, mesh_id in mappings.items():
     pred = PredictionTuple(
-        source_prefix='uberon',
+        source_prefix="uberon",
         source_id=uberon_id,
-        source_name=g.nodes[uberon_id]['name'],
-        relation='skos:exactMatch',
-        target_prefix='mesh',
+        source_name=g.nodes[uberon_id]["name"],
+        relation="skos:exactMatch",
+        target_prefix="mesh",
         target_identifier=mesh_id,
         target_name=mesh_client.get_mesh_name(mesh_id),
-        type='lexical',
+        type="lexical",
         confidence=0.9,
-        source='generate_uberon_mesh_mappings.py'
+        source="generate_uberon_mesh_mappings.py",
     )
     predictions.append(pred)
 
-append_prediction_tuples(predictions, deduplicate=True,
-                         sort=True)
+append_prediction_tuples(predictions, deduplicate=True, sort=True)

--- a/scripts/generate_uberon_mesh_mappings.py
+++ b/scripts/generate_uberon_mesh_mappings.py
@@ -1,0 +1,40 @@
+import gilda
+import obonet
+from indra.databases import mesh_client
+from biomappings.resources import PredictionTuple, \
+    append_prediction_tuples
+
+g = obonet.read_obo('/Users/ben/src/uberon/src/ontology/uberon-edit.obo')
+
+mappings = {}
+for node, data in g.nodes(data=True):
+    if not node.startswith('UBERON'):
+        continue
+    mesh_refs = [xref for xref in data.get('xref', [])
+                 if xref.startswith('MESH')]
+    if mesh_refs:
+        continue
+    matches = gilda.ground(data['name'])
+    if matches and matches[0].term.db == 'MESH':
+        mappings[node] = matches[0].term.id
+
+print('Found %d UBERON->MESH mappings.' % len(mappings))
+
+predictions = []
+for uberon_id, mesh_id in mappings.items():
+    pred = PredictionTuple(
+        source_prefix='uberon',
+        source_id=uberon_id,
+        source_name=g.nodes[uberon_id]['name'],
+        relation='skos:exactMatch',
+        target_prefix='mesh',
+        target_identifier=mesh_id,
+        target_name=mesh_client.get_mesh_name(mesh_id),
+        type='lexical',
+        confidence=0.9,
+        source='generate_uberon_mesh_mappings.py'
+    )
+    predictions.append(pred)
+
+append_prediction_tuples(predictions, deduplicate=True,
+                         sort=True)

--- a/scripts/generate_uberon_mesh_mappings.py
+++ b/scripts/generate_uberon_mesh_mappings.py
@@ -1,6 +1,9 @@
+"""Generate mappings using Gilda from UBERON to MeSH."""
+
 import gilda
 import obonet
 from indra.databases import mesh_client
+
 from biomappings.resources import PredictionTuple, append_prediction_tuples
 
 g = obonet.read_obo("/Users/ben/src/uberon/src/ontology/uberon-edit.obo")

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -939,6 +939,7 @@ reactome	R-XTR-8877627	Vitamin E	skos:exactMatch	mesh	D014810	Vitamin E	manually
 reactome	R-XTR-9664873	Pexophagy	speciesSpecific	go	GO:0030242	autophagy of peroxisome	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-XTR-983189	Kinesins	speciesSpecific	fplx	Kinesin	Kinesin	manually_reviewed	orcid:0000-0003-4423-4370
 uberon	UBERON:0000104	life cycle	skos:exactMatch	mesh	D008018	Life Cycle Stages	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:2001977	pad	skos:exactMatch	mesh	D058729	Peripheral Arterial Disease	manually_reviewed	orcid:0000-0001-9439-5346
 umls	C0006142	Malignant neoplasm of breast	skos:exactMatch	mesh	D001943	Breast Neoplasms	manual	orcid:0000-0002-6601-2165
 wikipathways	WP1060	Matrix Metalloproteinases	speciesSpecific	fplx	MMP	MMP	manually_reviewed	orcid:0000-0003-4423-4370
 wikipathways	WP1176	Matrix Metalloproteinases	speciesSpecific	fplx	MMP	MMP	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -938,6 +938,7 @@ reactome	R-XTR-8877627	Vitamin E	skos:exactMatch	chebi	CHEBI:46430	(-)-alpha-toc
 reactome	R-XTR-8877627	Vitamin E	skos:exactMatch	mesh	D014810	Vitamin E	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-XTR-9664873	Pexophagy	speciesSpecific	go	GO:0030242	autophagy of peroxisome	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-XTR-983189	Kinesins	speciesSpecific	fplx	Kinesin	Kinesin	manually_reviewed	orcid:0000-0003-4423-4370
+uberon	UBERON:0000104	life cycle	skos:exactMatch	mesh	D008018	Life Cycle Stages	manually_reviewed	orcid:0000-0001-9439-5346
 umls	C0006142	Malignant neoplasm of breast	skos:exactMatch	mesh	D001943	Breast Neoplasms	manual	orcid:0000-0002-6601-2165
 wikipathways	WP1060	Matrix Metalloproteinases	speciesSpecific	fplx	MMP	MMP	manually_reviewed	orcid:0000-0003-4423-4370
 wikipathways	WP1176	Matrix Metalloproteinases	speciesSpecific	fplx	MMP	MMP	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -939,6 +939,7 @@ reactome	R-XTR-8877627	Vitamin E	skos:exactMatch	mesh	D014810	Vitamin E	manually
 reactome	R-XTR-9664873	Pexophagy	speciesSpecific	go	GO:0030242	autophagy of peroxisome	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-XTR-983189	Kinesins	speciesSpecific	fplx	Kinesin	Kinesin	manually_reviewed	orcid:0000-0003-4423-4370
 uberon	UBERON:0000104	life cycle	skos:exactMatch	mesh	D008018	Life Cycle Stages	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0022469	primary olfactory cortex	skos:exactMatch	mesh	D066194	Olfactory Cortex	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:2001977	pad	skos:exactMatch	mesh	D058729	Peripheral Arterial Disease	manually_reviewed	orcid:0000-0001-9439-5346
 umls	C0006142	Malignant neoplasm of breast	skos:exactMatch	mesh	D001943	Breast Neoplasms	manual	orcid:0000-0002-6601-2165
 wikipathways	WP1060	Matrix Metalloproteinases	speciesSpecific	fplx	MMP	MMP	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -5338,6 +5338,7 @@ uberon	UBERON:0008974	apocrine gland	skos:exactMatch	mesh	D001050	Apocrine Gland
 uberon	UBERON:0009755	spermaceti	skos:exactMatch	mesh	C009301	spermaceti	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0009757	ambergris	skos:exactMatch	mesh	D018648	Ambergris	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0010264	hepatopancreas	skos:exactMatch	mesh	D043143	Hepatopancreas	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0010361	synostosis	skos:exactMatch	mesh	D013580	Synostosis	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0010725	accessory navicular bone	skos:exactMatch	mesh	C536002	Accessory navicular bone	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0011119	carpometacarpal joint	skos:exactMatch	mesh	D052737	Carpometacarpal Joints	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0011166	patellofemoral joint	skos:exactMatch	mesh	D057071	Patellofemoral Joint	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -5231,6 +5231,111 @@ reactome	R-SCE-73843	5-Phosphoribose 1-diphosphate biosynthesis	speciesSpecific	
 reactome	R-SPO-73843	5-Phosphoribose 1-diphosphate biosynthesis	speciesSpecific	go	GO:0006015	5-phosphoribose 1-diphosphate biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-SSC-73843	5-Phosphoribose 1-diphosphate biosynthesis	speciesSpecific	go	GO:0006015	5-phosphoribose 1-diphosphate biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-XTR-73843	5-Phosphoribose 1-diphosphate biosynthesis	speciesSpecific	go	GO:0006015	5-phosphoribose 1-diphosphate biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+uberon	UBERON:0000017	exocrine pancreas	skos:exactMatch	mesh	D046790	Pancreas, Exocrine	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000105	life cycle stage	skos:exactMatch	mesh	D008018	Life Cycle Stages	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000120	blood brain barrier	skos:exactMatch	mesh	D001812	Blood-Brain Barrier	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000127	facial nucleus	skos:exactMatch	mesh	D065828	Facial Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000159	anal canal	skos:exactMatch	mesh	D001003	Anal Canal	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000175	pleural effusion	skos:exactMatch	mesh	D010996	Pleural Effusion	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000220	atlanto-occipital joint	skos:exactMatch	mesh	D001269	Atlanto-Occipital Joint	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000387	meniscus	skos:exactMatch	mesh	D000072600	Meniscus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000569	ileocecal valve	skos:exactMatch	mesh	D007080	Ileocecal Valve	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0000939	imaginal disc	skos:exactMatch	mesh	D060227	Imaginal Discs	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001049	neural tube	skos:exactMatch	mesh	D054259	Neural Tube	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001156	ascending colon	skos:exactMatch	mesh	D044682	Colon, Ascending	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001157	transverse colon	skos:exactMatch	mesh	D044684	Colon, Transverse	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001158	descending colon	skos:exactMatch	mesh	D044683	Colon, Descending	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001347	white adipose tissue	skos:exactMatch	mesh	D052436	Adipose Tissue, White	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001473	lymphatic vessel	skos:exactMatch	mesh	D042601	Lymphatic Vessels	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001642	superior sagittal sinus	skos:exactMatch	mesh	D054063	Superior Sagittal Sinus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001715	oculomotor nuclear complex	skos:exactMatch	mesh	D065838	Oculomotor Nuclear Complex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001806	sympathetic ganglion	skos:exactMatch	mesh	D005728	Ganglia, Sympathetic	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001808	parasympathetic ganglion	skos:exactMatch	mesh	D005726	Ganglia, Parasympathetic	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001823	nasal cartilage	skos:exactMatch	mesh	D055171	Nasal Cartilages	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001856	semicircular duct	skos:exactMatch	mesh	D054776	Semicircular Ducts	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001862	vestibular labyrinth	skos:exactMatch	mesh	D014722	Vestibule, Labyrinth	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001863	scala vestibuli	skos:exactMatch	mesh	D054738	Scala Vestibuli	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001883	olfactory tubercle	skos:exactMatch	mesh	D066208	Olfactory Tubercle	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001907	zona incerta	skos:exactMatch	mesh	D065820	Zona Incerta	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001944	pretectal region	skos:exactMatch	mesh	D066250	Pretectal Region	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001977	blood serum	skos:exactMatch	mesh	D044967	Serum	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0001995	fibrocartilage	skos:exactMatch	mesh	D051445	Fibrocartilage	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002020	gray matter	skos:exactMatch	mesh	D066128	Gray Matter	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002043	dorsal raphe nucleus	skos:exactMatch	mesh	D065847	Dorsal Raphe Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002062	endocardial cushion	skos:exactMatch	mesh	D054089	Endocardial Cushions	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002120	pronephros	skos:exactMatch	mesh	D060910	Pronephros	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002128	superior olivary complex	skos:exactMatch	mesh	D065832	Superior Olivary Complex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002145	interpeduncular nucleus	skos:exactMatch	mesh	D066268	Interpeduncular Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002152	middle cerebellar peduncle	skos:exactMatch	mesh	D065837	Middle Cerebellar Peduncle	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002156	nucleus raphe magnus	skos:exactMatch	mesh	D065846	Nucleus Raphe Magnus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002157	nucleus raphe pallidus	skos:exactMatch	mesh	D065848	Nucleus Raphe Pallidus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002186	bronchiole	skos:exactMatch	mesh	D055745	Bronchioles	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002236	costal cartilage	skos:exactMatch	mesh	D066186	Costal Cartilage	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002242	nucleus pulposus	skos:exactMatch	mesh	D000070614	Nucleus Pulposus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002316	white matter	skos:exactMatch	mesh	D066127	White Matter	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002373	palatine tonsil	skos:exactMatch	mesh	D014066	Palatine Tonsil	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002396	vomer	skos:exactMatch	mesh	D055172	Vomer	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002409	pericardial fluid	skos:exactMatch	mesh	D000069236	Pericardial Fluid	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002469	esophagus mucosa	skos:exactMatch	mesh	D000071041	Esophageal Mucosa	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002493	uterine artery	skos:exactMatch	mesh	D055988	Uterine Artery	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002540	lateral line system	skos:exactMatch	mesh	D053403	Lateral Line System	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002548	larva	skos:exactMatch	mesh	D007814	Larva	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002600	limbic lobe	skos:exactMatch	mesh	D065726	Limbic Lobe	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002623	cerebral peduncle	skos:exactMatch	mesh	D065850	Cerebral Peduncle	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002631	cerebral crus	skos:exactMatch	mesh	D065843	Cerebral Crus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002639	midbrain reticular formation	skos:exactMatch	mesh	D066265	Midbrain Reticular Formation	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002682	abducens nucleus	skos:exactMatch	mesh	D065827	Abducens Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002684	nucleus raphe obscurus	skos:exactMatch	mesh	D065849	Nucleus Raphe Obscurus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002743	basal forebrain	skos:exactMatch	mesh	D066187	Basal Forebrain	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002883	central amygdaloid nucleus	skos:exactMatch	mesh	D066274	Central Amygdaloid Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002894	olfactory cortex	skos:exactMatch	mesh	D066194	Olfactory Cortex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0002932	trapezoid body	skos:exactMatch	mesh	D065833	Trapezoid Body	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003023	pontine tegmentum	skos:exactMatch	mesh	D065821	Pontine Tegmentum	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003044	uncinate fasciculus	skos:exactMatch	mesh	D000083382	Uncinate Fasciculus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003075	neural plate	skos:exactMatch	mesh	D054258	Neural Plate	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003143	pupa	skos:exactMatch	mesh	D011679	Pupa	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003209	blood nerve barrier	skos:exactMatch	mesh	D049428	Blood-Nerve Barrier	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003460	arm bone	skos:exactMatch	mesh	D050280	Arm Bones	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003462	facial bone	skos:exactMatch	mesh	D005147	Facial Bones	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003881	CA1 field of hippocampus	skos:exactMatch	mesh	D056547	CA1 Region, Hippocampal	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003882	CA2 field of hippocampus	skos:exactMatch	mesh	D056651	CA2 Region, Hippocampal	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0003883	CA3 field of hippocampus	skos:exactMatch	mesh	D056654	CA3 Region, Hippocampal	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0004341	primitive streak	skos:exactMatch	mesh	D054240	Primitive Streak	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0004676	spinal cord lateral horn	skos:exactMatch	mesh	D066152	Spinal Cord Lateral Horn	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0004720	cerebellar vermis	skos:exactMatch	mesh	D065814	Cerebellar Vermis	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0004725	piriform cortex	skos:exactMatch	mesh	D066195	Piriform Cortex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0004749	blastodisc	skos:exactMatch	mesh	D054239	Blastodisc	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005290	myelencephalon	skos:exactMatch	mesh	D054024	Myelencephalon	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005335	chorioallantoic membrane	skos:exactMatch	mesh	D049033	Chorioallantoic Membrane	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005403	ventral striatum	skos:exactMatch	mesh	D066328	Ventral Striatum	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005408	circumventricular organ	skos:exactMatch	mesh	D066280	Circumventricular Organs	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005438	coronary sinus	skos:exactMatch	mesh	D054326	Coronary Sinus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005456	jugular foramen	skos:exactMatch	mesh	D000080869	Jugular Foramina	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005631	extraembryonic membrane	skos:exactMatch	mesh	D005321	Extraembryonic Membranes	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005742	adventitia	skos:exactMatch	mesh	D063194	Adventitia	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0005777	glomerular basement membrane	skos:exactMatch	mesh	D050533	Glomerular Basement Membrane	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006083	perirhinal cortex	skos:exactMatch	mesh	D000071039	Perirhinal Cortex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006108	corticomedial nuclear complex	skos:exactMatch	mesh	D066276	Corticomedial Nuclear Complex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006444	annulus fibrosus	skos:exactMatch	mesh	D000070616	Annulus Fibrosus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006562	pharynx	skos:exactMatch	mesh	D010614	Pharynx	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006588	round ligament of liver	skos:exactMatch	mesh	D000069592	Round Ligament of Liver	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006589	round ligament of uterus	skos:exactMatch	mesh	D012404	Round Ligament of Uterus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006614	aponeurosis	skos:exactMatch	mesh	D000070606	Aponeurosis	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006675	venous valve	skos:exactMatch	mesh	D055422	Venous Valves	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0006812	mental foramen	skos:exactMatch	mesh	D000080383	Mental Foramen	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007109	meconium	skos:exactMatch	mesh	D008470	Meconium	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007132	head kidney	skos:exactMatch	mesh	D060226	Head Kidney	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007268	upper esophageal sphincter	skos:exactMatch	mesh	D049631	Esophageal Sphincter, Upper	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007329	pancreatic duct	skos:exactMatch	mesh	D010183	Pancreatic Ducts	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007412	midbrain raphe nuclei	skos:exactMatch	mesh	D066267	Midbrain Raphe Nuclei	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007632	Barrington's nucleus	skos:exactMatch	mesh	D065835	Barrington's Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007634	parabrachial nucleus	skos:exactMatch	mesh	D065823	Parabrachial Nucleus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0007703	spinothalamic tract	skos:exactMatch	mesh	D013133	Spinothalamic Tracts	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0008266	periodontal ligament	skos:exactMatch	mesh	D010513	Periodontal Ligament	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0008269	nacre	skos:exactMatch	mesh	D060734	Nacre	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0008826	pulmonary surfactant	skos:exactMatch	mesh	D011663	Pulmonary Surfactants	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0008974	apocrine gland	skos:exactMatch	mesh	D001050	Apocrine Glands	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0009755	spermaceti	skos:exactMatch	mesh	C009301	spermaceti	manually_reviewed	orcid:0000-0001-9439-5346
 umls	C0001973	Alcoholic Intoxication, Chronic	skos:narrower	mesh	D000435	Alcoholic Intoxication	manual	orcid:0000-0003-4423-4370
 umls	C0004352	Autistic Disorder	skos:exactMatch	mesh	D001321	Autistic Disorder	manual	orcid:0000-0003-4423-4370
 umls	C0006118	Brain Neoplasms	skos:exactMatch	mesh	D001932	Brain Neoplasms	manual	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -5336,6 +5336,30 @@ uberon	UBERON:0008269	nacre	skos:exactMatch	mesh	D060734	Nacre	manually_reviewed
 uberon	UBERON:0008826	pulmonary surfactant	skos:exactMatch	mesh	D011663	Pulmonary Surfactants	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0008974	apocrine gland	skos:exactMatch	mesh	D001050	Apocrine Glands	manually_reviewed	orcid:0000-0001-9439-5346
 uberon	UBERON:0009755	spermaceti	skos:exactMatch	mesh	C009301	spermaceti	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0009757	ambergris	skos:exactMatch	mesh	D018648	Ambergris	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0010264	hepatopancreas	skos:exactMatch	mesh	D043143	Hepatopancreas	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0010725	accessory navicular bone	skos:exactMatch	mesh	C536002	Accessory navicular bone	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0011119	carpometacarpal joint	skos:exactMatch	mesh	D052737	Carpometacarpal Joints	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0011166	patellofemoral joint	skos:exactMatch	mesh	D057071	Patellofemoral Joint	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0011390	pudendal nerve	skos:exactMatch	mesh	D060525	Pudendal Nerve	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0012245	silk	skos:exactMatch	mesh	D047011	Silk	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0013422	infratemporal fossa	skos:exactMatch	mesh	D000080884	Infratemporal Fossa	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0014374	embryoid body	skos:exactMatch	mesh	D058732	Embryoid Bodies	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0014398	respiratory muscle	skos:exactMatch	mesh	D012132	Respiratory Muscles	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0014537	periamygdaloid cortex	skos:exactMatch	mesh	D066277	Periamygdaloid Cortex	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0015488	sural nerve	skos:exactMatch	mesh	D013497	Sural Nerve	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0016884	shoulder joint	skos:exactMatch	mesh	D012785	Shoulder Joint	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0018144	cervical rib	skos:exactMatch	mesh	D057070	Cervical Rib	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0018388	cercaria	skos:exactMatch	mesh	D058487	Cercaria	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0034971	aortic body	skos:exactMatch	mesh	D001016	Aortic Bodies	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0035032	abdominal oblique muscle	skos:exactMatch	mesh	D000071596	Abdominal Oblique Muscles	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0035618	parapharyngeal space	skos:exactMatch	mesh	D000080886	Parapharyngeal Space	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0036016	honey	skos:exactMatch	mesh	D006722	Honey	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:0036145	glymphatic system	skos:exactMatch	mesh	D000077502	Glymphatic System	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:1000010	mole	skos:exactMatch	mesh	D009506	Nevus	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:2001553	manubrium	skos:exactMatch	mesh	D008371	Manubrium	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:4000104	ganoine	skos:exactMatch	mesh	C067951	ganoine	manually_reviewed	orcid:0000-0001-9439-5346
+uberon	UBERON:4200215	suture	skos:exactMatch	mesh	D013537	Sutures	manually_reviewed	orcid:0000-0001-9439-5346
 umls	C0001973	Alcoholic Intoxication, Chronic	skos:narrower	mesh	D000435	Alcoholic Intoxication	manual	orcid:0000-0003-4423-4370
 umls	C0004352	Autistic Disorder	skos:exactMatch	mesh	D001321	Autistic Disorder	manual	orcid:0000-0003-4423-4370
 umls	C0006118	Brain Neoplasms	skos:exactMatch	mesh	D001932	Brain Neoplasms	manual	orcid:0000-0003-4423-4370


### PR DESCRIPTION
This PR creates a set of predictions between UBERON and MeSH for UBERON entries where such a mapping is missing. I also confirmed 130 of the mappings as correct. 