### PR TITLE
Predict and curate CL-MESH mappings

### DIFF
--- a/scripts/generate_cl_mesh_mappings.py
+++ b/scripts/generate_cl_mesh_mappings.py
@@ -20,7 +20,7 @@ for node, data in g.nodes(data=True):
     has_mesh_id = False
     for value in [data.get('def', '')] + data.get('synonym', []) + data.get(
             'xref', []):
-        if re.match(mesh_tree_pattern, value) or re.match(mesh_id_pattern, value):
+        if re.findall(mesh_tree_pattern, value) or re.findall(mesh_id_pattern, value):
             has_mesh_id = True
             break
 
@@ -52,7 +52,7 @@ print("Found %d CL->MESH mappings." % len(mappings))
 predictions = []
 for cl_id, mesh_id in mappings.items():
     pred = PredictionTuple(
-        source_prefix="uberon",
+        source_prefix="cl",
         source_id=cl_id,
         source_name=g.nodes[cl_id]["name"],
         relation="skos:exactMatch",

--- a/scripts/generate_cl_mesh_mappings.py
+++ b/scripts/generate_cl_mesh_mappings.py
@@ -1,0 +1,69 @@
+"""Generate mappings using Gilda from CL to MeSH."""
+import re
+
+import gilda
+import obonet
+from indra.databases import mesh_client
+
+from biomappings.resources import PredictionTuple, append_prediction_tuples
+
+g = obonet.read_obo("https://raw.githubusercontent.com/obophenotype/cell-ontology/master/cl-basic.obo")
+
+mesh_tree_pattern = re.compile(r'MESH:[A-Z][0-9]+\.[0-9.]+')
+mesh_id_pattern = re.compile(r'MESH:[CD][0-9]+')
+
+mappings = {}
+for node, data in g.nodes(data=True):
+    if not node.startswith('CL:'):
+        continue
+
+    has_mesh_id = False
+    for value in [data.get('def', '')] + data.get('synonym', []) + data.get(
+            'xref', []):
+        if re.match(mesh_tree_pattern, value) or re.match(mesh_id_pattern, value):
+            has_mesh_id = True
+            break
+
+    if has_mesh_id:
+        continue
+
+    matches = gilda.ground(data['name'])
+    if not matches:
+        if data['name'].endswith(' cells'):
+            matches = gilda.ground(data['name'].replace(' cells', ''))
+        elif data['name'].endswith(' cell'):
+            matches = gilda.ground(data['name'].replace(' cell', ''))
+    if not matches:
+        continue
+
+    mesh_ids = set()
+    for match in matches:
+        groundings = match.get_groundings()
+        mesh_ids |= {id for ns, id in groundings if ns == 'MESH'}
+    if len(mesh_ids) > 1:
+        print('Multiple MESH IDs for %s' % node)
+    elif len(mesh_ids) == 1:
+        mesh_id = list(mesh_ids)[0]
+        mappings[node] = mesh_id
+
+
+print("Found %d CL->MESH mappings." % len(mappings))
+
+predictions = []
+for cl_id, mesh_id in mappings.items():
+    pred = PredictionTuple(
+        source_prefix="uberon",
+        source_id=cl_id,
+        source_name=g.nodes[cl_id]["name"],
+        relation="skos:exactMatch",
+        target_prefix="mesh",
+        target_identifier=mesh_id,
+        target_name=mesh_client.get_mesh_name(mesh_id),
+        type="lexical",
+        confidence=0.9,
+        source="generate_cl_mesh_mappings.py",
+    )
+    predictions.append(pred)
+
+append_prediction_tuples(predictions, deduplicate=True, sort=True)
+

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -42,6 +42,34 @@ chebi	CHEBI:29806	fumarate(2-)	skos:exactMatch	mesh	D005650	Fumarates	manually_r
 chebi	CHEBI:33224	chromane	skos:exactMatch	mesh	D002839	Chromans	manually_reviewed	orcid:0000-0003-4423-4370
 chebi	CHEBI:45373	sulfanilamide	skos:exactMatch	mesh	D013424	Sulfanilamides	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:6456	lidocaine	skos:exactMatch	mesh	C511998	Lidoderm	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000345	dental papilla cell	skos:exactMatch	mesh	D003771	Dental Papilla	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000384	ligament cell	skos:exactMatch	mesh	D008022	Ligaments	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000388	tendon cell	skos:exactMatch	mesh	D013710	Tendons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000412	polyploid cell	skos:exactMatch	mesh	D011123	Polyploidy	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000413	haploid cell	skos:exactMatch	mesh	D006238	Haploidy	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000415	diploid cell	skos:exactMatch	mesh	D004171	Diploidy	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000477	ovarian follicle cell	skos:exactMatch	mesh	D006080	Ovarian Follicle	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000548	animal cell	skos:exactMatch	mesh	D000818	Animals	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000565	fat body cell	skos:exactMatch	mesh	D005216	Fat Body	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000737	striated muscle cell	skos:exactMatch	mesh	D054792	Muscle, Striated	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002148	dental pulp cell	skos:exactMatch	mesh	D003782	Dental Pulp	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002367	trabecular meshwork cell	skos:exactMatch	mesh	D014129	Trabecular Meshwork	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002372	myotube	skos:exactMatch	mesh	D018485	Muscle Fibers, Skeletal	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002521	subcutaneous fat cell	skos:exactMatch	mesh	D050151	Subcutaneous Fat	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002559	hair follicle cell	skos:exactMatch	mesh	D018859	Hair Follicle	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0011012	neural crest cell	skos:exactMatch	mesh	D009432	Neural Crest	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0011026	progenitor cell	skos:exactMatch	mesh	D013234	Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1000147	heart valve cell	skos:exactMatch	mesh	D006351	Heart Valves	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1000497	kidney cell	skos:exactMatch	mesh	D007668	Kidney	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1000504	kidney medulla cell	skos:exactMatch	mesh	D007679	Kidney Medulla	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1000505	kidney pelvis cell	skos:exactMatch	mesh	D007682	Kidney Pelvis	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1000507	kidney tubule cell	skos:exactMatch	mesh	D007684	Kidney Tubules	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1001319	bladder cell	skos:exactMatch	mesh	D001743	Urinary Bladder	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1001320	urethra cell	skos:exactMatch	mesh	D014521	Urethra	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:2000004	pituitary gland cell	skos:exactMatch	mesh	D010902	Pituitary Gland	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:2000021	sebaceous gland cell	skos:exactMatch	mesh	D012627	Sebaceous Glands	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:2000022	cardiac septum cell	skos:exactMatch	mesh	D006346	Heart Septum	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:2000030	hypothalamus cell	skos:exactMatch	mesh	D007031	Hypothalamus	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	mesh	D006394	Hemangiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	umls	C0018923	Hemangiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	umls	C0278592	Adult Angiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -55,7 +55,9 @@ cl	CL:0000477	ovarian follicle cell	skos:exactMatch	mesh	D006080	Ovarian Follicl
 cl	CL:0000548	animal cell	skos:exactMatch	mesh	D000818	Animals	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000565	fat body cell	skos:exactMatch	mesh	D005216	Fat Body	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000737	striated muscle cell	skos:exactMatch	mesh	D054792	Muscle, Striated	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000968	Be cell	skos:exactMatch	mesh	D001471	Barrett Esophagus	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002148	dental pulp cell	skos:exactMatch	mesh	D003782	Dental Pulp	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002258	thyroid follicular cell	skos:exactMatch	mesh	D000072637	Thyroid Epithelial Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002367	trabecular meshwork cell	skos:exactMatch	mesh	D014129	Trabecular Meshwork	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002372	myotube	skos:exactMatch	mesh	D018485	Muscle Fibers, Skeletal	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002521	subcutaneous fat cell	skos:exactMatch	mesh	D050151	Subcutaneous Fat	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -42,12 +42,15 @@ chebi	CHEBI:29806	fumarate(2-)	skos:exactMatch	mesh	D005650	Fumarates	manually_r
 chebi	CHEBI:33224	chromane	skos:exactMatch	mesh	D002839	Chromans	manually_reviewed	orcid:0000-0003-4423-4370
 chebi	CHEBI:45373	sulfanilamide	skos:exactMatch	mesh	D013424	Sulfanilamides	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:6456	lidocaine	skos:exactMatch	mesh	C511998	Lidoderm	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000149	visual pigment cell	skos:exactMatch	mesh	D012168	Retinal Pigments	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000322	pneumocyte	skos:exactMatch	mesh	D056809	Alveolar Epithelial Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000345	dental papilla cell	skos:exactMatch	mesh	D003771	Dental Papilla	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000384	ligament cell	skos:exactMatch	mesh	D008022	Ligaments	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000388	tendon cell	skos:exactMatch	mesh	D013710	Tendons	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000412	polyploid cell	skos:exactMatch	mesh	D011123	Polyploidy	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000413	haploid cell	skos:exactMatch	mesh	D006238	Haploidy	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000415	diploid cell	skos:exactMatch	mesh	D004171	Diploidy	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000429	imaginal disc cell	skos:exactMatch	mesh	D060227	Imaginal Discs	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000477	ovarian follicle cell	skos:exactMatch	mesh	D006080	Ovarian Follicle	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000548	animal cell	skos:exactMatch	mesh	D000818	Animals	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000565	fat body cell	skos:exactMatch	mesh	D005216	Fat Body	manually_reviewed	orcid:0000-0001-9439-5346
@@ -57,6 +60,10 @@ cl	CL:0002367	trabecular meshwork cell	skos:exactMatch	mesh	D014129	Trabecular M
 cl	CL:0002372	myotube	skos:exactMatch	mesh	D018485	Muscle Fibers, Skeletal	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002521	subcutaneous fat cell	skos:exactMatch	mesh	D050151	Subcutaneous Fat	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002559	hair follicle cell	skos:exactMatch	mesh	D018859	Hair Follicle	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0008022	endocardial cushion cell	skos:exactMatch	mesh	D054089	Endocardial Cushions	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0009004	retinal cell	skos:exactMatch	mesh	D012172	Retinaldehyde	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0009005	salivary gland cell	skos:exactMatch	mesh	D012469	Salivary Glands	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0010005	atrioventricular bundle cell	skos:exactMatch	mesh	D002036	Bundle of His	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0011012	neural crest cell	skos:exactMatch	mesh	D009432	Neural Crest	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0011026	progenitor cell	skos:exactMatch	mesh	D013234	Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:1000147	heart valve cell	skos:exactMatch	mesh	D006351	Heart Valves	manually_reviewed	orcid:0000-0001-9439-5346
@@ -64,6 +71,7 @@ cl	CL:1000497	kidney cell	skos:exactMatch	mesh	D007668	Kidney	manually_reviewed	
 cl	CL:1000504	kidney medulla cell	skos:exactMatch	mesh	D007679	Kidney Medulla	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:1000505	kidney pelvis cell	skos:exactMatch	mesh	D007682	Kidney Pelvis	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:1000507	kidney tubule cell	skos:exactMatch	mesh	D007684	Kidney Tubules	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:1001225	kidney collecting duct cell	skos:exactMatch	mesh	D007685	Kidney Tubules, Collecting	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:1001319	bladder cell	skos:exactMatch	mesh	D001743	Urinary Bladder	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:1001320	urethra cell	skos:exactMatch	mesh	D014521	Urethra	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:2000004	pituitary gland cell	skos:exactMatch	mesh	D010902	Pituitary Gland	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1919,6 +1919,7 @@ cl	CL:0000060	odontoblast	skos:exactMatch	mesh	D009804	Odontoblasts	manually_rev
 cl	CL:0000081	blood cell	skos:exactMatch	mesh	D001773	Blood Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000084	T cell	skos:exactMatch	mesh	D013601	T-Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000092	osteoclast	skos:exactMatch	mesh	D010010	Osteoclasts	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000101	sensory neuron	skos:exactMatch	mesh	D011984	Sensory Receptor Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000108	cholinergic neuron	skos:exactMatch	mesh	D059329	Cholinergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000109	adrenergic neuron	skos:exactMatch	mesh	D059331	Adrenergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000119	cerebellar Golgi cell	skos:exactMatch	mesh	D000080906	Cerebellar Golgi Cells	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1952,6 +1953,7 @@ cl	CL:0000650	mesangial cell	skos:exactMatch	mesh	D050527	Mesangial Cells	manual
 cl	CL:0000683	ependymoglial cell	skos:exactMatch	mesh	D063928	Ependymoglial Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000700	dopaminergic neuron	skos:exactMatch	mesh	D059290	Dopaminergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000711	cumulus cell	skos:exactMatch	mesh	D054885	Cumulus Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000723	somatic stem cell	skos:exactMatch	mesh	D053687	Adult Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000738	leukocyte	skos:exactMatch	mesh	D007962	Leukocytes	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000740	retinal ganglion cell	skos:exactMatch	mesh	D012165	Retinal Ganglion Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000746	cardiac muscle cell	skos:exactMatch	mesh	D032383	Myocytes, Cardiac	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1965,11 +1967,14 @@ cl	CL:0000850	serotonergic neuron	skos:exactMatch	mesh	D059326	Serotonergic Neur
 cl	CL:0000891	foam cell	skos:exactMatch	mesh	D005487	Foam Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000893	thymocyte	skos:exactMatch	mesh	D060168	Thymocytes	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000899	T-helper 17 cell	skos:exactMatch	mesh	D058504	Th17 Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000912	helper T cell	skos:exactMatch	mesh	D006377	T-Lymphocytes, Helper-Inducer	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0001070	beige adipocyte	skos:exactMatch	mesh	D000069797	Adipocytes, Beige	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002090	polar body	skos:exactMatch	mesh	D059705	Polar Bodies	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002092	bone marrow cell	skos:exactMatch	mesh	D001854	Bone Marrow Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002198	oncocyte	skos:exactMatch	mesh	D024862	Oxyphil Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002246	peripheral blood stem cell	skos:exactMatch	mesh	D000072916	Peripheral Blood Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002248	pluripotent stem cell	skos:exactMatch	mesh	D039904	Pluripotent Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002275	pancreatic PP cell	skos:exactMatch	mesh	D050418	Pancreatic Polypeptide-Secreting Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002309	corticotroph	skos:exactMatch	mesh	D052680	Corticotrophs	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002312	somatotroph	skos:exactMatch	mesh	D052683	Somatotrophs	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002320	connective tissue cell	skos:exactMatch	mesh	D003239	Connective Tissue Cells	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1909,6 +1909,78 @@ chebi	CHEBI:9969	Verruculotoxin	skos:exactMatch	mesh	C011563	verruculotoxin	manu
 chebi	CHEBI:9970	Verticine	skos:exactMatch	mesh	C014242	verticine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:9973	vibriobactin	skos:exactMatch	mesh	C040227	vibriobactin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:9976	Vicine	skos:exactMatch	mesh	C009661	vicine	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000000	cell	skos:exactMatch	mesh	D002477	Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000010	cultured cell	skos:exactMatch	mesh	D002478	Cells, Cultured	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000023	oocyte	skos:exactMatch	mesh	D009865	Oocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000025	egg cell	skos:exactMatch	mesh	D010063	Ovum	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000037	hematopoietic stem cell	skos:exactMatch	mesh	D006412	Hematopoietic Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000052	totipotent stem cell	skos:exactMatch	mesh	D039901	Totipotent Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000060	odontoblast	skos:exactMatch	mesh	D009804	Odontoblasts	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000081	blood cell	skos:exactMatch	mesh	D001773	Blood Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000084	T cell	skos:exactMatch	mesh	D013601	T-Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000092	osteoclast	skos:exactMatch	mesh	D010010	Osteoclasts	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000108	cholinergic neuron	skos:exactMatch	mesh	D059329	Cholinergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000109	adrenergic neuron	skos:exactMatch	mesh	D059331	Adrenergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000119	cerebellar Golgi cell	skos:exactMatch	mesh	D000080906	Cerebellar Golgi Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000148	melanocyte	skos:exactMatch	mesh	D008544	Melanocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000164	enteroendocrine cell	skos:exactMatch	mesh	D019858	Enteroendocrine Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000178	Leydig cell	skos:exactMatch	mesh	D007985	Leydig Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000197	sensory receptor cell	skos:exactMatch	mesh	D011984	Sensory Receptor Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000207	olfactory receptor cell	skos:exactMatch	mesh	D018034	Olfactory Receptor Neurons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000234	phagocyte	skos:exactMatch	mesh	D010586	Phagocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000235	macrophage	skos:exactMatch	mesh	D008264	Macrophages	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000236	B cell	skos:exactMatch	mesh	D001402	B-Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000255	eukaryotic cell	skos:exactMatch	mesh	D005057	Eukaryotic Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000362	epidermal cell	skos:exactMatch	mesh	D000078404	Epidermal Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000371	protoplast	skos:exactMatch	mesh	D011523	Protoplasts	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000442	follicular dendritic cell	skos:exactMatch	mesh	D020566	Dendritic Cells, Follicular	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000451	dendritic cell	skos:exactMatch	mesh	D003713	Dendritic Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000453	Langerhans cell	skos:exactMatch	mesh	D007801	Langerhans Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000476	thyrotroph	skos:exactMatch	mesh	D052684	Thyrotrophs	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000520	prokaryotic cell	skos:exactMatch	mesh	D011387	Prokaryotic Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000542	lymphocyte	skos:exactMatch	mesh	D008214	Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000546	T-helper 2 cell	skos:exactMatch	mesh	D018418	Th2 Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000553	megakaryocyte progenitor cell	skos:exactMatch	mesh	D055016	Megakaryocyte Progenitor Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000558	reticulocyte	skos:exactMatch	mesh	D012156	Reticulocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000584	enterocyte	skos:exactMatch	mesh	D020895	Enterocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000617	GABAergic neuron	skos:exactMatch	mesh	D059330	GABAergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000622	acinar cell	skos:exactMatch	mesh	D061354	Acinar Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000623	natural killer cell	skos:exactMatch	mesh	D007694	Killer Cells, Natural	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000650	mesangial cell	skos:exactMatch	mesh	D050527	Mesangial Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000683	ependymoglial cell	skos:exactMatch	mesh	D063928	Ependymoglial Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000700	dopaminergic neuron	skos:exactMatch	mesh	D059290	Dopaminergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000711	cumulus cell	skos:exactMatch	mesh	D054885	Cumulus Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000738	leukocyte	skos:exactMatch	mesh	D007962	Leukocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000740	retinal ganglion cell	skos:exactMatch	mesh	D012165	Retinal Ganglion Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000746	cardiac muscle cell	skos:exactMatch	mesh	D032383	Myocytes, Cardiac	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000763	myeloid cell	skos:exactMatch	mesh	D022423	Myeloid Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000765	erythroblast	skos:exactMatch	mesh	D004900	Erythroblasts	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000771	eosinophil	skos:exactMatch	mesh	D004804	Eosinophils	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000775	neutrophil	skos:exactMatch	mesh	D009504	Neutrophils	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000786	plasma cell	skos:exactMatch	mesh	D010950	Plasma Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000815	regulatory T cell	skos:exactMatch	mesh	D050378	T-Lymphocytes, Regulatory	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000850	serotonergic neuron	skos:exactMatch	mesh	D059326	Serotonergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000891	foam cell	skos:exactMatch	mesh	D005487	Foam Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000893	thymocyte	skos:exactMatch	mesh	D060168	Thymocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000899	T-helper 17 cell	skos:exactMatch	mesh	D058504	Th17 Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0001070	beige adipocyte	skos:exactMatch	mesh	D000069797	Adipocytes, Beige	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002090	polar body	skos:exactMatch	mesh	D059705	Polar Bodies	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002092	bone marrow cell	skos:exactMatch	mesh	D001854	Bone Marrow Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002246	peripheral blood stem cell	skos:exactMatch	mesh	D000072916	Peripheral Blood Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002248	pluripotent stem cell	skos:exactMatch	mesh	D039904	Pluripotent Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002309	corticotroph	skos:exactMatch	mesh	D052680	Corticotrophs	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002312	somatotroph	skos:exactMatch	mesh	D052683	Somatotrophs	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002320	connective tissue cell	skos:exactMatch	mesh	D003239	Connective Tissue Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002322	embryonic stem cell	skos:exactMatch	mesh	D053595	Embryonic Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002369	fungal spore	skos:exactMatch	mesh	D013172	Spores, Fungal	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002410	pancreatic stellate cell	skos:exactMatch	mesh	D058954	Pancreatic Stellate Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002418	hemangioblast	skos:exactMatch	mesh	D055018	Hemangioblasts	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002453	oligodendrocyte precursor cell	skos:exactMatch	mesh	D000073637	Oligodendrocyte Precursor Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002496	intraepithelial lymphocyte	skos:exactMatch	mesh	D000075942	Intraepithelial Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002573	Schwann cell	skos:exactMatch	mesh	D012583	Schwann Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0008002	skeletal muscle fiber	skos:exactMatch	mesh	D018485	Muscle Fibers, Skeletal	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0010017	zygote	skos:exactMatch	mesh	D015053	Zygote	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0010021	cardiac myoblast	skos:exactMatch	mesh	D032386	Myoblasts, Cardiac	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0040002	aspirin allergy	skos:exactMatch	umls	C0004058	Allergy to aspirin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040004	amoxicillin allergy	skos:exactMatch	umls	C0571417	Allergy to amoxicillin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040005	ceftriaxone allergy	skos:exactMatch	umls	C0571463	Allergy to ceftriaxone	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1924,6 +1924,7 @@ cl	CL:0000109	adrenergic neuron	skos:exactMatch	mesh	D059331	Adrenergic Neurons	
 cl	CL:0000119	cerebellar Golgi cell	skos:exactMatch	mesh	D000080906	Cerebellar Golgi Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000148	melanocyte	skos:exactMatch	mesh	D008544	Melanocytes	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000164	enteroendocrine cell	skos:exactMatch	mesh	D019858	Enteroendocrine Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000171	pancreatic A cell	skos:exactMatch	mesh	D050416	Glucagon-Secreting Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000178	Leydig cell	skos:exactMatch	mesh	D007985	Leydig Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000197	sensory receptor cell	skos:exactMatch	mesh	D011984	Sensory Receptor Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000207	olfactory receptor cell	skos:exactMatch	mesh	D018034	Olfactory Receptor Neurons	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1946,6 +1947,7 @@ cl	CL:0000584	enterocyte	skos:exactMatch	mesh	D020895	Enterocytes	manually_revie
 cl	CL:0000617	GABAergic neuron	skos:exactMatch	mesh	D059330	GABAergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000622	acinar cell	skos:exactMatch	mesh	D061354	Acinar Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000623	natural killer cell	skos:exactMatch	mesh	D007694	Killer Cells, Natural	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000647	multinucleated giant cell	skos:exactMatch	mesh	D015726	Giant Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000650	mesangial cell	skos:exactMatch	mesh	D050527	Mesangial Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000683	ependymoglial cell	skos:exactMatch	mesh	D063928	Ependymoglial Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0000700	dopaminergic neuron	skos:exactMatch	mesh	D059290	Dopaminergic Neurons	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1974,6 +1974,7 @@ cl	CL:0002092	bone marrow cell	skos:exactMatch	mesh	D001854	Bone Marrow Cells	ma
 cl	CL:0002198	oncocyte	skos:exactMatch	mesh	D024862	Oxyphil Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002246	peripheral blood stem cell	skos:exactMatch	mesh	D000072916	Peripheral Blood Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002248	pluripotent stem cell	skos:exactMatch	mesh	D039904	Pluripotent Stem Cells	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0002257	epithelial cell of thyroid gland	skos:exactMatch	mesh	D000072637	Thyroid Epithelial Cells	manual	orcid:0000-0001-9439-5346
 cl	CL:0002275	pancreatic PP cell	skos:exactMatch	mesh	D050418	Pancreatic Polypeptide-Secreting Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002309	corticotroph	skos:exactMatch	mesh	D052680	Corticotrophs	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002312	somatotroph	skos:exactMatch	mesh	D052683	Somatotrophs	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1986,6 +1987,7 @@ cl	CL:0002453	oligodendrocyte precursor cell	skos:exactMatch	mesh	D000073637	Oli
 cl	CL:0002496	intraepithelial lymphocyte	skos:exactMatch	mesh	D000075942	Intraepithelial Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0002573	Schwann cell	skos:exactMatch	mesh	D012583	Schwann Cells	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0008002	skeletal muscle fiber	skos:exactMatch	mesh	D018485	Muscle Fibers, Skeletal	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0010003	epithelial cell of alveolus of lung	skos:exactMatch	mesh	D056809	Alveolar Epithelial Cells	manual	orcid:0000-0001-9439-5346
 cl	CL:0010017	zygote	skos:exactMatch	mesh	D015053	Zygote	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0010021	cardiac myoblast	skos:exactMatch	mesh	D032386	Myoblasts, Cardiac	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0040002	aspirin allergy	skos:exactMatch	umls	C0004058	Allergy to aspirin	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/unsure.tsv
+++ b/src/biomappings/resources/unsure.tsv
@@ -9,6 +9,8 @@ ccle	ECC4	ECC4	skos:exactMatch	cellosaurus	CVCL_1190	ECC4	manually_reviewed	orci
 ccle	ECC4	ECC4	skos:exactMatch	depmap	ACH-002024	ECC4	manually_reviewed	orcid:0000-0001-9439-5346
 ccle	NCIH1048_LUNG	NCI-H1048	skos:exactMatch	efo	0002248	NCI-H1048	manually_reviewed	orcid:0000-0001-9439-5346
 ccle	TE4_OESOPHAGUS	TE-4	skos:exactMatch	cellosaurus	CVCL_F784	TE4 [Mouse hybridoma]	manually_reviewed	orcid:0000-0003-4423-4370
+cl	CL:0000798	gamma-delta T cell	skos:exactMatch	mesh	D000075942	Intraepithelial Lymphocytes	manually_reviewed	orcid:0000-0001-9439-5346
+cl	CL:0000816	immature B cell	skos:exactMatch	mesh	D054448	Precursor Cells, B-Lymphoid	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050025	human granulocytic anaplasmosis	skos:exactMatch	mesh	D000712	Anaplasmosis	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0050035	African tick-bite fever	skos:exactMatch	mesh	D000073605	Spotted Fever Group Rickettsiosis	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0050201	nephropathia epidemica	skos:exactMatch	mesh	D006480	Hemorrhagic Fever with Renal Syndrome	manually_reviewed	orcid:0000-0001-9439-5346


### PR DESCRIPTION
This PR adds a script to find missing mappings between CL and MESH to create 119 mappings. I curated 79 as correct, 38 as incorrect and 2 unsure. I then curated 2 more mappings manually.