### PR TITLE
Miscellaneous curation

### DIFF
--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -387,6 +387,7 @@ mesh	D004410	Dyslexia	skos:exactMatch	doid	DOID:13365	reading disorder	manually_
 mesh	D004932	Esophageal and Gastric Varices	skos:exactMatch	doid	DOID:112	esophageal varix	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D005319	Fetal Hemoglobin	skos:exactMatch	efo	0004576	fetal hemoglobin measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D005351	Fibromatosis, Gingival	skos:exactMatch	doid	DOID:0060466	gingival fibromatosis	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D005390	Fires	skos:exactMatch	ncit	C63143	Device Fire	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005621	Friedreich Ataxia	skos:exactMatch	doid	DOID:0111218	Friedreich ataxia 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D005776	Gaucher Disease	skos:exactMatch	doid	DOID:0110957	Gaucher's disease type I	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D006429	Hemiplegia	skos:exactMatch	doid	DOID:10967	spastic hemiplegia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -444,6 +445,7 @@ mesh	D012559	Schizophrenia	skos:exactMatch	doid	DOID:5418	schizoaffective disord
 mesh	D012734	Disorders of Sex Development	skos:exactMatch	doid	DOID:3765	pseudohermaphroditism	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D012804	Sick Sinus Syndrome	skos:exactMatch	doid	DOID:0050824	sinoatrial node disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D012878	Skin Neoplasms	skos:exactMatch	doid	DOID:8923	skin melanoma	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D012915	Soaps	skos:exactMatch	ncit	C42983	Soap Dosage Form	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D013125	Spinal Neoplasms	skos:exactMatch	doid	DOID:14150	spinal cord lymphoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D013274	Stomach Neoplasms	skos:exactMatch	doid	DOID:5517	stomach carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D013700	Giant Cell Arteritis	skos:exactMatch	go	GO:0033968	glutaryl-7-aminocephalosporanic-acid acylase activity	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1450,6 +1450,7 @@ chebi	CHEBI:22563	anion	skos:exactMatch	mesh	D000838	Anions	manually_reviewed	or
 chebi	CHEBI:22586	antioxidant	skos:exactMatch	mesh	D000975	Antioxidants	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:22587	antiviral agent	skos:exactMatch	mesh	D000998	Antiviral Agents	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:22990	camalexin	skos:exactMatch	mesh	C102405	camalexin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:2469	adefovir	skos:exactMatch	mesh	C053001	adefovir	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:25176	mannuronic acid	skos:exactMatch	mesh	C008324	mannuronic acid	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:25348	methylxanthine	skos:exactMatch	mesh	C008514	methylxanthine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:25458	myrtenal	skos:exactMatch	mesh	C061545	myrtenal	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1612,6 +1613,7 @@ chebi	CHEBI:43602	obeticholic acid	skos:exactMatch	mesh	C464660	obeticholic acid
 chebi	CHEBI:43636	5-iodouracil	skos:exactMatch	mesh	C048747	5-iodouracil	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:4388	deltamethrin	skos:exactMatch	mesh	C017180	decamethrin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:43931	methyllycaconitine	skos:exactMatch	mesh	C054634	methyllycaconitine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:44143	emivirine	skos:exactMatch	mesh	C083858	emivirine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:4429	deoxypodophyllotoxin	skos:exactMatch	mesh	C014451	deoxypodophyllotoxin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:45487	13-cis-retinal	skos:exactMatch	mesh	C031338	13-cis-retinal	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:4566	Dihydrogriesenin	skos:exactMatch	mesh	C052634	dihydrogriesenin	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2414,27 +2416,80 @@ mesh	C000170	ferric ferrocyanide	skos:exactMatch	ncit	C47532	Ferric Ferrocyanide
 mesh	C000179	N-acetylaspartate	skos:exactMatch	ncit	C118887	N-Acetylaspartate	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000203	deoxyaminopteroic acid	skos:exactMatch	ncit	C157133	Deoxyaminopteroic Acid	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000288	ritrosulfan	skos:exactMatch	ncit	C75294	Ritrosulfan	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000589490	Omaveloxolone	skos:exactMatch	ncit	C113443	Omaveloxolone	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000590398	DEPDC5 protein, human	skos:exactMatch	uniprot	O75140	DEPDC5	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C000590915	Aticaprant	skos:exactMatch	ncit	C170144	Aticaprant	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000592662	DORAVIRINE	skos:exactMatch	ncit	C171848	Doravirine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000592900	FJX1 protein, human	skos:exactMatch	uniprot	Q86VR8	FJX1	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000592911	Abituzumab	skos:exactMatch	ncit	C82422	Abituzumab	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000594804	Tovetumab	skos:exactMatch	ncit	C82684	Tovetumab	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000595215	Polyethylene Glycol 6000	skos:exactMatch	ncit	C84085	Polyethylene Glycol 6000	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000596385	Jalili syndrome	skos:exactMatch	doid	DOID:0111404	Jalili syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000597312	Gefapixant	skos:exactMatch	ncit	C166945	Gefapixant	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000598645	Spheroid body myopathy	skos:exactMatch	doid	DOID:0080091	spheroid body myopathy	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000599766	Otilimab	skos:exactMatch	ncit	C170271	Otilimab	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000600094	Fletikumab	skos:exactMatch	ncit	C171836	Fletikumab	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000602642	PLX8394	skos:exactMatch	ncit	C113330	BRAF Inhibitor PLX8394	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000603632	sodium glycididazole	skos:exactMatch	ncit	C77889	Sodium Glycididazole	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C000606551	remdesivir	skos:exactMatch	ncit	C152185	Remdesivir	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000607229	Solitomab	skos:exactMatch	ncit	C77854	Solitomab	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000608559	Miransertib	skos:exactMatch	ncit	C99172	Miransertib	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000608854	Bilateral Optic Nerve Meningioma	skos:exactMatch	ncit	C5304	Bilateral Optic Nerve Meningioma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000609611	AZD2461	skos:exactMatch	ncit	C95201	PARP Inhibitor AZD2461	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000615187	Plutonium-239	skos:exactMatch	ncit	C29774	Plutonium-239	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000615784	ASP5878	skos:exactMatch	ncit	C122719	FGFR Inhibitor ASP5878	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000620255	GOT1 protein, human	skos:exactMatch	uniprot	P17174	GOT1	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C000621508	F2RL1 protein, human	skos:exactMatch	uniprot	P55085	F2RL1	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C000622468	TMEM65 protein, human	skos:exactMatch	uniprot	Q6PI78	TMEM65	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000623728	Rhinovirus C	skos:exactMatch	ncit	C112409	Rhinovirus C	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000623735	Rhinovirus B	skos:exactMatch	ncit	C112408	Rhinovirus B	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000623787	Rhinovirus A	skos:exactMatch	ncit	C112407	Rhinovirus A	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000625752	Omiganan	skos:exactMatch	ncit	C166886	Omiganan	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000626007	MAGEB4 protein, human	skos:exactMatch	uniprot	O15481	MAGEB4	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000626124	NGLY1 deficiency	skos:exactMatch	doid	DOID:0060728	NGLY1-deficiency	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000626257	Icrucumab	skos:exactMatch	ncit	C79808	Icrucumab	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000626466	ENDOD1 protein, human	skos:exactMatch	uniprot	O94919	ENDOD1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000627234	OBE2109	skos:exactMatch	ncit	C148479	Linzagolix	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C000627735	FGF22 protein, human	skos:exactMatch	uniprot	Q9HCT0	FGF22	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000629536	Inotersen	skos:exactMatch	ncit	C121667	Inotersen	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000629634	Rezafungin	skos:exactMatch	ncit	C152205	Rezafungin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000629807	Dorzagliatin	skos:exactMatch	ncit	C169919	Dorzagliatin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000629870	Esketamine	skos:exactMatch	ncit	C81400	Esketamine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000629884	Risdiplam	skos:exactMatch	ncit	C167001	Risdiplam	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000630155	Rogaratinib	skos:exactMatch	ncit	C112205	Rogaratinib	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000631478	LINGO2 protein, human	skos:exactMatch	uniprot	Q7L985	LINGO2	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000631489	CKD-581	skos:exactMatch	ncit	C148157	HDAC Inhibitor CKD-581	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000631507	CNTD2 protein, human	skos:exactMatch	uniprot	Q9H8S5	CNTD2	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000635094	Shewanella algae	skos:exactMatch	ncit	C123551	Shewanella algae	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635101	Serratia rubidaea	skos:exactMatch	ncit	C86741	Serratia rubidaea	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635105	Serratia plymuthica	skos:exactMatch	ncit	C86740	Serratia plymuthica	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635107	Serratia odorifera	skos:exactMatch	ncit	C86739	Serratia odorifera	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635113	Serratia fonticola	skos:exactMatch	ncit	C86737	Serratia fonticola	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635114	Serratia ficaria	skos:exactMatch	ncit	C86736	Serratia ficaria	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635391	Selenomonas sputigena	skos:exactMatch	ncit	C86734	Selenomonas sputigena	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635394	Selenomonas noxia	skos:exactMatch	ncit	C86733	Selenomonas noxia	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635563	Pseudomonas otitidis	skos:exactMatch	ncit	C128547	Pseudomonas otitidis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635564	Pseudomonas oryzihabitans	skos:exactMatch	ncit	C76319	Pseudomonas oryzihabitans	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635571	Pseudomonas nitroreducens	skos:exactMatch	ncit	C124365	Pseudomonas nitroreducens	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000635800	Salmonella bongori	skos:exactMatch	ncit	C91842	Salmonella bongori	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000635836	Pseudomonas mosselii	skos:exactMatch	ncit	C86703	Pseudomonas mosselii	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635854	Pseudomonas luteola	skos:exactMatch	ncit	C86701	Pseudomonas luteola	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000635978	Tetragenococcus solitarius	skos:exactMatch	ncit	C86821	Tetragenococcus solitarius	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637523	Streptomyces albus	skos:exactMatch	ncit	C86812	Streptomyces albus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637590	Streptococcus vestibularis	skos:exactMatch	ncit	C86810	Streptococcus vestibularis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637593	Streptococcus urinalis	skos:exactMatch	ncit	C128549	Streptococcus urinalis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637594	Streptococcus uberis	skos:exactMatch	ncit	C86809	Streptococcus uberis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637777	Tatumella ptyseos	skos:exactMatch	ncit	C86819	Tatumella ptyseos	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637780	Tatlockia micdadei	skos:exactMatch	ncit	C86817	Tatlockia micdadei	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637881	Streptococcus sanguinis	skos:exactMatch	ncit	C86806	Streptococcus sanguinis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637892	Streptococcus porcinus	skos:exactMatch	ncit	C86802	Streptococcus porcinus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637895	Streptococcus pluranimalium	skos:exactMatch	ncit	C124412	Streptococcus pluranimalium	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637906	Streptococcus parasanguinis	skos:exactMatch	ncit	C86800	Streptococcus parasanguinis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637922	Streptococcus massiliensis	skos:exactMatch	ncit	C124410	Streptococcus massiliensis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637927	Streptococcus lutetiensis	skos:exactMatch	ncit	C124409	Streptococcus lutetiensis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637932	Streptococcus infantarius	skos:exactMatch	ncit	C86793	Streptococcus infantarius	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637964	Streptococcus cristatus	skos:exactMatch	ncit	C86788	Streptococcus cristatus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000637995	Ruminococcus gnavus	skos:exactMatch	ncit	C124373	Ruminococcus gnavus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C000639838	Sphingomonas paucimobilis	skos:exactMatch	ncit	C86749	Sphingomonas paucimobilis	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C000650035	Citrobacter farmeri	skos:exactMatch	ncit	C86264	Citrobacter farmeri	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C000656407	MSANTD3 protein, human	skos:exactMatch	uniprot	Q96H12	MSANTD3	manually_reviewed	orcid:0000-0003-4423-4370
@@ -3277,6 +3332,7 @@ mesh	C562489	Lymphoid Interstitial Pneumonia	skos:exactMatch	doid	DOID:0050159	l
 mesh	C562509	Popliteal Pterygium Syndrome	skos:exactMatch	doid	DOID:0060055	popliteal pterygium syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562524	Fibrochondrogenesis	skos:exactMatch	doid	DOID:0060465	fibrochondrogenesis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562538	Cerebrocostomandibular Syndrome	skos:exactMatch	doid	DOID:0111248	cerebrocostomandibular syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C562562	Colonic Atresia	skos:exactMatch	hp	HP:0010448	Colonic atresia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C562568	Cerebellar Hypoplasia	skos:exactMatch	doid	DOID:0070338	cerebellar hypoplasia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562587	Purine Nucleoside Phosphorylase Deficiency	skos:exactMatch	doid	DOID:5813	purine nucleoside phosphorylase deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562592	Xeroderma Pigmentosum, Complementation Group F	skos:exactMatch	doid	DOID:0110848	xeroderma pigmentosum group F	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3952,6 +4008,7 @@ mesh	D000002	Temefos	skos:exactMatch	ncit	C80606	Temefos	manually_reviewed	orcid
 mesh	D000019	Abortifacient Agents	skos:exactMatch	chebi	CHEBI:50691	abortifacient	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000067128	Extracellular Vesicles	skos:exactMatch	go	GO:1903561	extracellular vesicle	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000067208	Shellfish Hypersensitivity	skos:exactMatch	doid	DOID:0060495	shellfish allergy	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D000067269	Diet, Vegan	skos:exactMatch	ncit	C15630	Vegan Diet	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000068180	Aripiprazole	skos:exactMatch	chebi	CHEBI:31236	aripiprazole	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000068296	Risedronic Acid	skos:exactMatch	chebi	CHEBI:8869	Risedronic acid	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000068298	Fluticasone	skos:exactMatch	chebi	CHEBI:5134	fluticasone	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4026,6 +4083,7 @@ mesh	D000070	Acebutolol	skos:exactMatch	chebi	CHEBI:2379	acebutolol	manually_rev
 mesh	D000070779	Giant Cell Tumor of Tendon Sheath	skos:exactMatch	doid	DOID:314	tenosynovial giant cell tumor	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D000071017	Hyperekplexia	skos:exactMatch	doid	DOID:0060695	hyperekplexia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D000071040	Axon Initial Segment	skos:exactMatch	go	GO:0043194	axon initial segment	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071071	Microaneurysm	skos:exactMatch	ncit	C35842	Microaneurysm	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000071182	Autophagosomes	skos:exactMatch	go	GO:0005776	autophagosome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000071218	Ultradian Rhythm	skos:exactMatch	go	GO:0007624	ultradian rhythm	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000071243	Zika Virus Infection	skos:exactMatch	ncit	C128423	Zika Virus Infection	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4347,6 +4405,7 @@ mesh	D000738	Androsterone	skos:exactMatch	chebi	CHEBI:16032	androsterone	manuall
 mesh	D000743	Anemia, Hemolytic	skos:exactMatch	doid	DOID:583	hemolytic anemia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D000777	Anesthetics	skos:exactMatch	chebi	CHEBI:38867	anaesthetic	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D000779	Anesthetics, Local	skos:exactMatch	chebi	CHEBI:36333	local anaesthetic	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000783	Aneurysm	skos:exactMatch	ncit	C26693	Aneurysm	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000793	Angioid Streaks	skos:exactMatch	doid	DOID:979	angioid streaks of choroid	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D000802	Angiotensin Amide	skos:exactMatch	chebi	CHEBI:135950	angiotensinamide	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D000803	Angiotensin I	skos:exactMatch	chebi	CHEBI:2718	Angiotensin I	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4592,6 +4651,7 @@ mesh	D002351	Carrageenan	skos:exactMatch	chebi	CHEBI:3435	carrageenan	manually_r
 mesh	D002354	Carteolol	skos:exactMatch	chebi	CHEBI:3437	carteolol	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002395	Catecholamines	skos:exactMatch	chebi	CHEBI:33567	catecholamine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002396	Catechols	skos:exactMatch	chebi	CHEBI:33566	catechols	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002408	Catheters, Indwelling	skos:exactMatch	ncit	C54729	Indwelling Catheter	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002412	Cations	skos:exactMatch	chebi	CHEBI:36916	cation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002433	Cefaclor	skos:exactMatch	chebi	CHEBI:3478	cefaclor	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002438	Cefoperazone	skos:exactMatch	chebi	CHEBI:3493	cefoperazone	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4680,6 +4740,7 @@ mesh	D003070	Coformycin	skos:exactMatch	chebi	CHEBI:16213	coformycin	manually_re
 mesh	D003071	Cognition	skos:exactMatch	go	GO:0050890	cognition	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003084	Colestipol	skos:exactMatch	chebi	CHEBI:3814	colestipol	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003094	Collagen	skos:exactMatch	chebi	CHEBI:3815	Collagen	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003111	Colonic Polyps	skos:exactMatch	ncit	C2954	Colon Polyp	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003141	Communicable Diseases	skos:exactMatch	doid	DOID:0050117	disease by infectious agent	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D003167	Complement Activation	skos:exactMatch	go	GO:0006956	complement activation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003214	Conditioning, Classical	skos:exactMatch	go	GO:0008306	associative learning	manually_reviewed	orcid:0000-0003-4423-4370
@@ -4730,6 +4791,7 @@ mesh	D003599	Cytoskeleton	skos:exactMatch	go	GO:0005856	cytoskeleton	manually_re
 mesh	D003600	Cytosol	skos:exactMatch	go	GO:0005829	cytosol	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003620	Dantrolene	skos:exactMatch	chebi	CHEBI:4317	dantrolene	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003623	Dark Adaptation	skos:exactMatch	go	GO:1990603	dark adaptation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003645	Death, Sudden	skos:exactMatch	ncit	C107103	Sudden Death	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003668	Pressure Ulcer	skos:exactMatch	doid	DOID:8717	decubitus ulcer	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D003672	Defecation	skos:exactMatch	go	GO:0030421	defecation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D003712	Dendrites	skos:exactMatch	go	GO:0030425	dendrite	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4741,6 +4803,7 @@ mesh	D003896	Desmosomes	skos:exactMatch	go	GO:0030057	desmosome	manually_reviewe
 mesh	D004031	Diestrus	skos:exactMatch	go	GO:0060207	diestrus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004063	Digestion	skos:exactMatch	go	GO:0007586	digestion	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004205	Cromolyn Sodium	skos:exactMatch	ncit	C28946	Cromolyn Sodium	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D004241	Diverticulum, Colon	skos:exactMatch	ncit	C34550	Colonic Diverticulum	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004260	DNA Repair	skos:exactMatch	go	GO:0006281	DNA repair	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004261	DNA Replication	skos:exactMatch	go	GO:0006260	DNA replication	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004263	DNA Tumor Viruses	skos:exactMatch	ncit	C14199	DNA Tumor Virus	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4773,6 +4836,7 @@ mesh	D005407	Flagella	skos:exactMatch	go	GO:0005929	cilium	manually_reviewed	orc
 mesh	D005416	Flavivirus	skos:exactMatch	ncit	C14208	Flavivirus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005427	Flocculation	skos:exactMatch	go	GO:0000128	flocculation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005498	Follicular Phase	skos:exactMatch	go	GO:0001541	ovarian follicle development	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D005596	Fractures, Closed	skos:exactMatch	ncit	C34623	Closed Fracture	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005602	France	skos:exactMatch	ncit	C16592	France	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005609	Free Radicals	skos:exactMatch	ncit	C512	Free Radical	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005615	Freezing	skos:exactMatch	ncit	C48160	Freezing	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4827,16 +4891,22 @@ mesh	D005762	Gastroenterology	skos:exactMatch	ncit	C16603	Gastroenterology	manua
 mesh	D005785	Gene Conversion	skos:exactMatch	go	GO:0035822	gene conversion	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005786	Gene Expression Regulation	skos:exactMatch	go	GO:0010468	regulation of gene expression	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005790	General Adaptation Syndrome	skos:exactMatch	go	GO:0051866	general adaptation syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005827	Genetics, Microbial	skos:exactMatch	ncit	C17940	Microbial Genetics	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005910	Glioma	skos:exactMatch	doid	DOID:0060108	brain glioma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D005943	Gluconeogenesis	skos:exactMatch	go	GO:0006094	gluconeogenesis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006019	Glycolysis	skos:exactMatch	go	GO:0006096	glycolytic process	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006031	Glycosylation	skos:exactMatch	go	GO:0070085	glycosylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006043	Goiter, Endemic	skos:exactMatch	ncit	C35023	Endemic Goiter	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006044	Goiter, Nodular	skos:exactMatch	ncit	C131437	Nodular Goiter	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006052	Gold Sodium Thiomalate	skos:exactMatch	ncit	C74037	Gold Sodium Thiomalate	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D006056	Golgi Apparatus	skos:exactMatch	go	GO:0005794	Golgi apparatus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006111	Graves Disease	skos:exactMatch	doid	DOID:10719	toxic diffuse goiter	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D006258	Head and Neck Neoplasms	skos:exactMatch	doid	DOID:11934	head and neck cancer	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D006319	Hearing Loss, Sensorineural	skos:exactMatch	ncit	C26739	Sensorineural Hearing Loss	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006333	Heart Failure	skos:exactMatch	doid	DOID:6000	congestive heart failure	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D006487	Hemostasis	skos:exactMatch	go	GO:0007599	hemostasis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006550	Hernia, Femoral	skos:exactMatch	ncit	C34689	Femoral Hernia	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006555	Hernia, Ventral	skos:exactMatch	ncit	C118313	Ventral Hernia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006561	Herpes Simplex	skos:exactMatch	doid	DOID:8566	herpes simplex	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D006570	Heterochromatin	skos:exactMatch	go	GO:0000792	heterochromatin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006605	Hibernation	skos:exactMatch	go	GO:0042750	hibernation	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4946,6 +5016,7 @@ mesh	D008686	Metestrus	skos:exactMatch	go	GO:0060210	metestrus	manually_reviewed
 mesh	D008745	Methylation	skos:exactMatch	go	GO:0032259	methylation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D008830	Microbodies	skos:exactMatch	go	GO:0042579	microbody	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D008841	Actin Cytoskeleton	skos:exactMatch	go	GO:0015629	actin cytoskeleton	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008860	Microscopy, Ultraviolet	skos:exactMatch	ncit	C16859	Ultraviolet Microscopy	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D008870	Microtubules	skos:exactMatch	go	GO:0005874	microtubule	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D008871	Microvilli	skos:exactMatch	go	GO:0005902	microvillus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D008883	Miliaria	skos:exactMatch	doid	DOID:11153	miliaria rubra	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5011,6 +5082,7 @@ mesh	D010942	Plant Viruses	skos:exactMatch	ncit	C14257	Plant Virus	manually_revi
 mesh	D010974	Platelet Aggregation	skos:exactMatch	go	GO:0070527	platelet aggregation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010998	Pleurisy	skos:exactMatch	doid	DOID:10247	pleurisy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011018	Pneumonia, Pneumococcal	skos:exactMatch	doid	DOID:0040084	Streptococcus pneumonia	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D011019	Pneumonia, Mycoplasma	skos:exactMatch	ncit	C122526	Mycoplasmal Pneumonia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011030	Pneumothorax	skos:exactMatch	doid	DOID:1673	pneumothorax	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011054	Poliovirus Vaccine, Inactivated	skos:exactMatch	ncit	C91715	Inactivated Poliovirus Vaccine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011120	Polyomavirus	skos:exactMatch	ncit	C14260	Polyomavirus	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5034,20 +5106,26 @@ mesh	D011485	Protein Binding	skos:exactMatch	go	GO:0005515	protein binding	manua
 mesh	D011489	Protein Denaturation	skos:exactMatch	go	GO:0030164	protein denaturation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011499	Protein Processing, Post-Translational	skos:exactMatch	go	GO:0043687	post-translational protein modification	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D011554	Pseudopodia	skos:exactMatch	go	GO:0031143	pseudopodium	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011588	Psychology, Educational	skos:exactMatch	ncit	C17030	Educational Psychology	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011618	Psychotic Disorders	skos:exactMatch	doid	DOID:2468	psychotic disorder	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011625	Pterygium	skos:exactMatch	doid	DOID:10526	conjunctival pterygium	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011768	Pyruvate Dehydrogenase Complex	skos:exactMatch	go	GO:0045254	pyruvate dehydrogenase complex	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D011839	Radiation, Ionizing	skos:exactMatch	ncit	C17052	Ionizing Radiation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011900	Ranula	skos:exactMatch	doid	DOID:12904	mucocele of salivary gland	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011906	Rat-Bite Fever	skos:exactMatch	doid	DOID:13238	Haverhill fever	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D011941	Receptors, Adrenergic	skos:exactMatch	ncit	C105824	Adrenergic Receptor	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011972	Receptor, Insulin	skos:exactMatch	ncit	C17072	Insulin Receptor	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011992	Endosomes	skos:exactMatch	go	GO:0005768	endosome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012038	Regeneration	skos:exactMatch	go	GO:0031099	regeneration	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012087	Reoviridae	skos:exactMatch	ncit	C112026	Reoviridae	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012098	Reproduction	skos:exactMatch	go	GO:0000003	reproduction	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012100	Reproduction, Asexual	skos:exactMatch	go	GO:0019954	asexual reproduction	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012140	Respiratory Tract Diseases	skos:exactMatch	doid	DOID:1579	respiratory system disease	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D012149	Restraint, Physical	skos:exactMatch	ncit	C158344	Physical Restraint	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012190	Retroviridae	skos:exactMatch	ncit	C14268	Retroviridae	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012209	Rhabdoviridae	skos:exactMatch	ncit	C112027	Rhabdoviridae	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012214	Rheumatic Heart Disease	skos:exactMatch	doid	DOID:0050827	rheumatic heart disease	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D012223	Rhinitis, Vasomotor	skos:exactMatch	ncit	C34988	Vasomotor Rhinitis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012229	Rhinovirus	skos:exactMatch	ncit	C77200	Rhinovirus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012254	Ribavirin	skos:exactMatch	ncit	C807	Ribavirin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012270	Ribosomes	skos:exactMatch	go	GO:0005840	ribosome	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5067,6 +5145,7 @@ mesh	D012625	Sebaceous Gland Diseases	skos:exactMatch	doid	DOID:9098	sebaceous g
 mesh	D012728	Sex Chromatin	skos:exactMatch	go	GO:0001739	sex chromatin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012730	Sex Chromosomes	skos:exactMatch	go	GO:0000803	sex chromosome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012733	Sex Differentiation	skos:exactMatch	go	GO:0007548	sex differentiation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012772	Shock, Septic	skos:exactMatch	ncit	C35018	Septic Shock	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012852	Sinusitis	skos:exactMatch	doid	DOID:0050127	sinusitis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D012893	Sleep Wake Disorders	skos:exactMatch	doid	DOID:535	sleep disorder	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D012901	Variola virus	skos:exactMatch	ncit	C96527	Variola Virus	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5136,6 +5215,7 @@ mesh	D014406	Tularemia	skos:exactMatch	doid	DOID:2123	tularemia	manually_reviewe
 mesh	D014484	United States Environmental Protection Agency	skos:exactMatch	ncit	C17236	Environmental Protection Agency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D014554	Urination	skos:exactMatch	go	GO:0060073	micturition	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D014570	Urologic Diseases	skos:exactMatch	doid	DOID:18	urinary system disease	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D014606	Uveitis, Anterior	skos:exactMatch	ncit	C35109	Anterior Uveitis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D014617	Vacuoles	skos:exactMatch	go	GO:0005773	vacuole	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D014661	Vasoconstriction	skos:exactMatch	go	GO:0042310	vasoconstriction	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D014664	Vasodilation	skos:exactMatch	go	GO:0042311	vasodilation	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5165,6 +5245,8 @@ mesh	D015636	Magnesium Chloride	skos:exactMatch	ncit	C29240	Magnesium Chloride	m
 mesh	D015774	Ganciclovir	skos:exactMatch	chebi	CHEBI:465284	ganciclovir	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015840	Oculomotor Nerve Diseases	skos:exactMatch	doid	DOID:562	third cranial nerve disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D015870	Gene Expression	skos:exactMatch	go	GO:0010467	gene expression	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015874	Yukon Territory	skos:exactMatch	ncit	C89818	Yukon	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015894	Genome, Human	skos:exactMatch	ncit	C16630	Human Genome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015922	Complement C1q	skos:exactMatch	go	GO:0062167	complement component C1q complex	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D016040	Lung Transplantation	skos:exactMatch	ncit	C15274	Lung Transplantation	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D016193	G1 Phase	skos:exactMatch	go	GO:0051318	G1 phase	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5176,6 +5258,7 @@ mesh	D016403	Lymphoma, Large B-Cell, Diffuse	skos:exactMatch	doid	DOID:0050745	d
 mesh	D016411	Lymphoma, T-Cell, Peripheral	skos:exactMatch	doid	DOID:0050749	peripheral T-cell lymphoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D016553	Purpura, Thrombocytopenic, Idiopathic	skos:exactMatch	doid	DOID:1587	thrombocytopenia due to platelet alloimmunization	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D016631	Lewy Bodies	skos:exactMatch	go	GO:0097413	Lewy body	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016679	Genome, Viral	skos:exactMatch	ncit	C17253	Viral Genome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D016723	Bone Remodeling	skos:exactMatch	go	GO:0046849	bone remodeling	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D016724	Empyema, Pleural	skos:exactMatch	doid	DOID:3798	pleural empyema	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D016856	Phlebovirus	skos:exactMatch	ncit	C112397	Phlebovirus	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5281,13 +5364,20 @@ mesh	D017693	Sodium Bicarbonate	skos:exactMatch	chebi	CHEBI:32139	sodium hydroge
 mesh	D017693	Sodium Bicarbonate	skos:exactMatch	ncit	C29457	Sodium Bicarbonate	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D017728	Lymphoma, Large-Cell, Anaplastic	skos:exactMatch	doid	DOID:0050744	anaplastic large cell lymphoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D017735	Virus Latency	skos:exactMatch	go	GO:0019042	viral latency	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D017824	Bone Cysts, Aneurysmal	skos:exactMatch	ncit	C3516	Aneurysmal Bone Cyst	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D017850	Economics, Pharmaceutical	skos:exactMatch	ncit	C142636	Pharmacoeconomics	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018087	Plastids	skos:exactMatch	go	GO:0009536	plastid	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018253	Adenoma, Villous	skos:exactMatch	doid	DOID:0050869	villous adenoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018271	Signal Recognition Particle	skos:exactMatch	go	GO:0048500	signal recognition particle	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018275	Carcinoma, Lobular	skos:exactMatch	doid	DOID:0050938	breast lobular carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D018286	Carcinoma, Giant Cell	skos:exactMatch	ncit	C3779	Giant Cell Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018293	Cystadenoma, Serous	skos:exactMatch	doid	DOID:5746	ovarian serous cystadenocarcinoma	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D018295	Neoplasms, Basal Cell	skos:exactMatch	ncit	C3784	Basal Cell Neoplasm	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018308	Papilloma, Inverted	skos:exactMatch	ncit	C3793	Inverted Papilloma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018312	Sex Cord-Gonadal Stromal Tumors	skos:exactMatch	doid	DOID:192	sex cord-gonadal stromal tumor	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D018329	Nevus, Blue	skos:exactMatch	ncit	C3803	Blue Nevus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018335	Rhabdoid Tumor	skos:exactMatch	ncit	C3808	Rhabdoid Tumor	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D018345	Mice, Knockout	skos:exactMatch	ncit	C14339	Knock-Out Mouse	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018375	Neutrophil Activation	skos:exactMatch	go	GO:0042119	neutrophil activation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018385	Centrosome	skos:exactMatch	go	GO:0005813	centrosome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018386	Kinetochores	skos:exactMatch	go	GO:0000776	kinetochore	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5301,6 +5391,8 @@ mesh	D018798	Anemia, Iron-Deficiency	skos:exactMatch	doid	DOID:11758	iron defici
 mesh	D018870	Endoplasmic Reticulum, Rough	skos:exactMatch	go	GO:0005791	rough endoplasmic reticulum	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018871	Endoplasmic Reticulum, Smooth	skos:exactMatch	go	GO:0005790	smooth endoplasmic reticulum	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018919	Neovascularization, Physiologic	skos:exactMatch	go	GO:0001525	angiogenesis	manual	orcid:0000-0001-9439-5346
+mesh	D018928	Immunity, Mucosal	skos:exactMatch	ncit	C17889	Mucosal Immunity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019047	Phantoms, Imaging	skos:exactMatch	ncit	C17892	Imaging Phantoms	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D019065	Virus Assembly	skos:exactMatch	go	GO:0019068	virion assembly	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D019069	Cell Respiration	skos:exactMatch	go	GO:0045333	cellular respiration	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D019108	Tight Junctions	skos:exactMatch	go	GO:0070160	tight junction	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5400,6 +5492,7 @@ mesh	D043762	Reproductive Behavior	skos:exactMatch	go	GO:0019098	reproductive be
 mesh	D043844	Crown Ethers	skos:exactMatch	chebi	CHEBI:37408	crown ether	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D043862	Rotaxanes	skos:exactMatch	chebi	CHEBI:50961	rotaxane	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D043863	Catenanes	skos:exactMatch	chebi	CHEBI:50960	catenane	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D043963	Diverticulosis, Colonic	skos:exactMatch	ncit	C34551	Colonic Diverticulosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D044004	Xanthones	skos:exactMatch	chebi	CHEBI:51149	xanthones	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D044045	Lipoxins	skos:exactMatch	chebi	CHEBI:6497	lipoxin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D044062	Prostaglandins I	skos:exactMatch	chebi	CHEBI:26345	prostaglandins I	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5438,8 +5531,13 @@ mesh	D048271	Chitosan	skos:exactMatch	chebi	CHEBI:16261	chitosan	manually_review
 mesh	D048288	Imidazolines	skos:exactMatch	chebi	CHEBI:53095	imidazolines	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D048289	Imidazolidines	skos:exactMatch	chebi	CHEBI:38261	imidazolidines	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D048348	Reverse Transcription	skos:exactMatch	go	GO:0001171	reverse transcription	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048369	MAP Kinase Kinase 1	skos:exactMatch	ncit	C17808	Dual Specificity Mitogen-Activated Protein Kinase Kinase 1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048370	MAP Kinase Kinase 2	skos:exactMatch	ncit	C106633	Dual Specificity Mitogen-Activated Protein Kinase Kinase 2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048371	MAP Kinase Kinase 3	skos:exactMatch	ncit	C125166	Dual Specificity Mitogen-Activated Protein Kinase Kinase 3	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D048588	Benzoxazines	skos:exactMatch	chebi	CHEBI:46969	benzoxazine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D048648	Macronucleus	skos:exactMatch	go	GO:0031039	macronucleus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048669	MAP Kinase Kinase 6	skos:exactMatch	ncit	C26485	Dual Specificity Mitogen-Activated Protein Kinase Kinase 6	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048670	MAP Kinase Kinase 4	skos:exactMatch	ncit	C97676	Dual Specificity Mitogen-Activated Protein Kinase Kinase 4	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D048708	Cell Growth Processes	skos:exactMatch	go	GO:0016049	cell growth	manual	orcid:0000-0001-9439-5346
 mesh	D048749	Cytokinesis	skos:exactMatch	go	GO:0000910	cytokinesis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D048750	Cell Nucleus Division	skos:exactMatch	go	GO:0000280	nuclear division	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -650,7 +650,9 @@ chebi	CHEBI:10303	alpha-Methyl-m-tyrosine	skos:exactMatch	mesh	C031476	alpha-met
 chebi	CHEBI:10319	1-naphthol	skos:exactMatch	mesh	C029350	1-naphthol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10324	alpha-peltatin	skos:exactMatch	mesh	C049798	alpha-peltatin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10352	beta-amyrin	skos:exactMatch	mesh	C036380	beta-amyrin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:104020	1-(2-methoxyphenyl)piperazine	skos:exactMatch	mesh	C040083	1-(2-methoxyphenyl)piperazine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10423	oleandrose	skos:exactMatch	mesh	C035441	oleandrose	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:104237	4-phenyl-1-(4-phenylbutyl)piperidine	skos:exactMatch	mesh	C094850	4-phenyl-1-(4-phenylbutyl)piperidine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10432	2-naphthol	skos:exactMatch	mesh	C028405	2-naphthol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10436	beta-ocimene	skos:exactMatch	mesh	C443996	beta-ocimene	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10437	beta-Peltatin A methyl ether	skos:exactMatch	mesh	C010499	beta-peltatin A methyl ether	manually_reviewed	orcid:0000-0001-9439-5346
@@ -659,6 +661,11 @@ chebi	CHEBI:10561	gamma-Coniceine	skos:exactMatch	mesh	C045984	gamma-coniceine	m
 chebi	CHEBI:10562	gamma-Fagarine	skos:exactMatch	mesh	C049193	gamma-fagarine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10577	gamma-terpinene	skos:exactMatch	mesh	C018669	gamma-terpinene	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10582	k-Strophanthoside	skos:exactMatch	mesh	C008240	K-strophanthoside	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:10586	3-carboxyphenyl phenylacetamidomethylphosphonate	skos:exactMatch	mesh	C061729	3-carboxyphenyl phenylacetamidomethylphosphonate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:10588	1-(3-chlorophenyl)piperazine	skos:exactMatch	mesh	C015068	1-(3-chlorophenyl)piperazine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:108597	4,5-dimethoxy-2-nitrobenzaldehyde	skos:exactMatch	mesh	C559746	4,5-dimethoxy-2-nitrobenzaldehyde	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:109540	3,4-dichloroisocoumarin	skos:exactMatch	mesh	C046235	3,4-dichloroisocoumarin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:111163	4-phenyl-1,2,3,4-tetrahydroisoquinoline	skos:exactMatch	mesh	C074266	4-phenyl-1,2,3,4-tetrahydroisoquinoline	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:11152	1,2-didecanoylglycerol	skos:exactMatch	mesh	C044297	1,2-didecanoylglycerol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:111521	valienone	skos:exactMatch	mesh	C586497	valienone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:113532	thymoquinone	skos:exactMatch	mesh	C003466	thymoquinone	manually_reviewed	orcid:0000-0001-9439-5346
@@ -668,6 +675,7 @@ chebi	CHEBI:116278	lomefloxacin	skos:exactMatch	mesh	C053091	lomefloxacin	manual
 chebi	CHEBI:116915	4-chloroacetanilide	skos:exactMatch	mesh	C012241	4-chloroacetanilide	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:1171	2-hydroxypropylphosphonic acid	skos:exactMatch	mesh	C531865	2-hydroxypropylphosphonic acid	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:119486	efavirenz	skos:exactMatch	mesh	C098320	efavirenz	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:124938	2-propyl-2-pentenoic acid	skos:exactMatch	mesh	C014168	2-propyl-2-pentenoic acid	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:125372	1-methyl-1,2,3,4-tetrahydroisoquinoline	skos:exactMatch	mesh	C050386	1-methyl-1,2,3,4-tetrahydroisoquinoline	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:125469	1-methylisoquinoline	skos:exactMatch	mesh	C103464	1-methylisoquinoline	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:125498	1,2,3,4-tetrahydroisoquinoline	skos:exactMatch	mesh	C014843	1,2,3,4-tetrahydroisoquinoline	manually_reviewed	orcid:0000-0001-9439-5346
@@ -679,6 +687,7 @@ chebi	CHEBI:131174	navitoclax	skos:exactMatch	mesh	C528561	navitoclax	manually_r
 chebi	CHEBI:131185	pinacol	skos:exactMatch	mesh	C000621940	pinacol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:131189	glass	skos:exactMatch	mesh	D005898	Glass	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:131355	triazoloquinazoline	skos:exactMatch	mesh	C000629127	triazoloquinazoline	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:131357	2-methyl-1,2-butanediol	skos:exactMatch	mesh	C473202	2-methyl-1,2-butanediol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:131358	BAY 60-6583	skos:exactMatch	mesh	C518875	BAY 60-6583	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:131383	2,2,4,4,6,8,8-heptamethylnonane	skos:exactMatch	mesh	C059167	2,2,4,4,6,8,8-heptamethylnonane	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:131424	(2-ethoxyethoxy)acetic acid	skos:exactMatch	mesh	C014537	(2-ethoxyethoxy)acetic acid	manually_reviewed	orcid:0000-0001-9439-5346
@@ -744,6 +753,7 @@ chebi	CHEBI:132448	perfluorohexanesulfonic acid	skos:exactMatch	mesh	C471071	per
 chebi	CHEBI:132450	1,1'-dihydroxy-3,4-didehydrolycopene	skos:exactMatch	mesh	C464490	1,1'-dihydroxy-3,4-didehydrolycopene	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132470	SW-163E	skos:exactMatch	mesh	C437364	SW-163E	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132487	hyrtial	skos:exactMatch	mesh	C045491	hyrtial	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:132509	HG-10-102-01	skos:exactMatch	mesh	C000622719	HG-10-102-01	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132512	wilforidine	skos:exactMatch	mesh	C583914	wilforidine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132546	3-cyanoalanine	skos:exactMatch	mesh	C009055	propargylglycine	manually_reviewed	orcid:0000-0003-4423-4370
 chebi	CHEBI:132593	monoisononyl phthalate	skos:exactMatch	mesh	C471400	monoisononylphthalate	manually_reviewed	orcid:0000-0001-9439-5346
@@ -780,6 +790,7 @@ chebi	CHEBI:132788	paeoniflorigenone	skos:exactMatch	mesh	C042713	paeoniflorigen
 chebi	CHEBI:132792	lactiflorin	skos:exactMatch	mesh	C494902	lactiflorin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132793	albiflorin	skos:exactMatch	mesh	C014959	albiflorin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132794	pinen-10-yl vicianoside	skos:exactMatch	mesh	C044909	pinen-10-yl vicianoside	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:132798	2-methylquinoxaline-6-carboxylic acid	skos:exactMatch	mesh	C509426	2-methylquinoxaline-6-carboxylic acid	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132812	2-methylquinoxaline	skos:exactMatch	mesh	C052307	2-methylquinoxaline	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132824	spathulenol	skos:exactMatch	mesh	C013258	spathulenol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:132826	versicolactone B	skos:exactMatch	mesh	C050784	versicolactone B	manually_reviewed	orcid:0000-0001-9439-5346
@@ -864,6 +875,7 @@ chebi	CHEBI:134206	2-methylserine	skos:exactMatch	mesh	C035563	2-methylserine	ma
 chebi	CHEBI:134353	deoxycohumulone	skos:exactMatch	mesh	C000591672	deoxycohumulone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134361	allylic alcohol	skos:exactMatch	mesh	C006463	allyl alcohol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134415	5-chloromuconolactone	skos:exactMatch	mesh	C088142	5-chloromuconolactone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:134517	20-carboxyleukotriene E4	skos:exactMatch	mesh	C095531	20-carboxyleukotriene E4	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134544	succinyl lactate	skos:exactMatch	mesh	C045176	succinyl lactate	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134627	leukotriene D3	skos:exactMatch	mesh	C028725	leukotriene D-3	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134677	crisaborole	skos:exactMatch	mesh	C543085	crisaborole	manually_reviewed	orcid:0000-0001-9439-5346
@@ -962,6 +974,7 @@ chebi	CHEBI:134885	albutoin	skos:exactMatch	mesh	C006443	albutoin	manually_revie
 chebi	CHEBI:134886	troxacitabine	skos:exactMatch	mesh	C074908	troxacitabine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134889	phenaglycodol	skos:exactMatch	mesh	C027886	phenaglycodol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134890	naftazone	skos:exactMatch	mesh	C005272	naftazone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:134892	5-aminolevulinic acid hexyl ester	skos:exactMatch	mesh	C419924	5-aminolevulinic acid hexyl ester	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134893	tramazoline	skos:exactMatch	mesh	C005370	tramazoline	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134894	butoctamide	skos:exactMatch	mesh	C013857	butoctamide	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134896	tiamenidine	skos:exactMatch	mesh	C010354	tiamenidine	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1073,6 +1086,7 @@ chebi	CHEBI:135077	amixetrine	skos:exactMatch	mesh	C012181	amixetrine	manually_r
 chebi	CHEBI:135078	cicletanine	skos:exactMatch	mesh	C038068	cicletanine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135081	fencibutirol	skos:exactMatch	mesh	C035344	fencibutirol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135082	mepindolol	skos:exactMatch	mesh	C015340	mepindolol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135084	miloxacin	skos:exactMatch	mesh	C023981	miloxacin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135087	clopirac	skos:exactMatch	mesh	C012847	clopirac	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135088	iprazochrome	skos:exactMatch	mesh	C009742	iprazochrome	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135089	propacetamol	skos:exactMatch	mesh	C063776	propacetamol	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1223,8 +1237,65 @@ chebi	CHEBI:135356	calusterone	skos:exactMatch	mesh	C073055	calusterone	manually
 chebi	CHEBI:135359	denopamine	skos:exactMatch	mesh	C037293	denopamine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135362	bietamiverine	skos:exactMatch	mesh	C005680	bietamiverine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135364	oxetorone	skos:exactMatch	mesh	C011962	oxetorone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135365	cyclodrine	skos:exactMatch	mesh	C002864	cyclodrine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135366	eterobarb	skos:exactMatch	mesh	C010451	eterobarb	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135371	bisaramil	skos:exactMatch	mesh	C045644	bisaramil	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135372	clostebol	skos:exactMatch	mesh	C076775	clostebol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135374	dimefline	skos:exactMatch	mesh	C015154	dimefline	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135375	guaiapate	skos:exactMatch	mesh	C001741	guaiapate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135376	bufetolol	skos:exactMatch	mesh	C100228	bufetolol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135377	cicloprolol	skos:exactMatch	mesh	C053708	cicloprolol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135379	cyamemazine	skos:exactMatch	mesh	C028457	cyamemazine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135381	trofosfamide	skos:exactMatch	mesh	C003726	trofosfamide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135382	amphotalide	skos:exactMatch	mesh	C005616	amphotalide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135385	viquidil	skos:exactMatch	mesh	C100255	viquidil	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135387	vorozole	skos:exactMatch	mesh	C060523	vorozole	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135389	etafenone	skos:exactMatch	mesh	C001162	etafenone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135396	dimenoxadol	skos:exactMatch	mesh	C005016	dimenoxadol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135397	difemerine	skos:exactMatch	mesh	C028777	difemerine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135398	norelgestromin	skos:exactMatch	mesh	C449219	norelgestromin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135401	clofibride	skos:exactMatch	mesh	C007089	clofibride	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135402	promestriene	skos:exactMatch	mesh	C013657	promestriene	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135404	flumethiazide	skos:exactMatch	mesh	C511328	flumethiazide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135406	bornaprine	skos:exactMatch	mesh	C006088	bornaprine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135408	oxomemazine	skos:exactMatch	mesh	C119593	oxomemazine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135413	protokylol	skos:exactMatch	mesh	C010312	protokylol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135418	oxitropium	skos:exactMatch	mesh	C017590	oxitropium	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135419	tropatepine	skos:exactMatch	mesh	C013322	tropatepine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135420	tetroxoprim	skos:exactMatch	mesh	C023507	tetroxoprim	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135421	fenalamide	skos:exactMatch	mesh	C004341	fenalamide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135422	progabide	skos:exactMatch	mesh	C017985	progabide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135424	oxeladin	skos:exactMatch	mesh	C005461	oxeladin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135427	pirifibrate	skos:exactMatch	mesh	C028670	pirifibrate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135428	nifurzide	skos:exactMatch	mesh	C029924	nifurzide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135429	buzepide metiodide	skos:exactMatch	mesh	C021334	buzepide metiodide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135435	fenquizone	skos:exactMatch	mesh	C007712	fenquizone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135436	pirmenol	skos:exactMatch	mesh	C024318	pirmenol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135439	propyromazine	skos:exactMatch	mesh	C009078	propyromazine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135440	rociverine	skos:exactMatch	mesh	C021082	rociverine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135441	metipamide	skos:exactMatch	mesh	C050506	metipamide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135443	poldine	skos:exactMatch	mesh	C100295	poldine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135447	penthienate	skos:exactMatch	mesh	C102258	penthienate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135454	sultosilic acid	skos:exactMatch	mesh	C024325	sultosilic acid	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135455	piketoprofen	skos:exactMatch	mesh	C048832	piketoprofen	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135463	beclobrate	skos:exactMatch	mesh	C020978	beclobrate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135464	chlorproethazine	skos:exactMatch	mesh	C054028	chlorproethazine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135465	arsthinol	skos:exactMatch	mesh	C546471	arsthinol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135466	nafamostat	skos:exactMatch	mesh	C032855	nafamostat	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135467	sulbactam pivoxyl	skos:exactMatch	mesh	C035975	sulbactam pivoxyl	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135469	benzpiperylone	skos:exactMatch	mesh	C519947	benzpiperylone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135471	clanobutin	skos:exactMatch	mesh	C019159	clanobutin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135472	embramine	skos:exactMatch	mesh	C005715	embramine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135474	intoplicine	skos:exactMatch	mesh	C081834	intoplicine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135475	leiopyrrole	skos:exactMatch	mesh	C008264	leiopyrrole	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135479	dipipanone	skos:exactMatch	mesh	C007527	dipipanone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135482	moquizone	skos:exactMatch	mesh	C002376	moquizone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135483	pipoxolan	skos:exactMatch	mesh	C000121	pipoxolan	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135486	posatirelin	skos:exactMatch	mesh	C055448	posatirelin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135488	quinbolone	skos:exactMatch	mesh	C005620	quinbolone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135490	motretinide	skos:exactMatch	mesh	C010832	motretinide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135493	quinfamide	skos:exactMatch	mesh	C026546	quinfamide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135494	isofezolac	skos:exactMatch	mesh	C020696	isofezolac	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135495	bevonium	skos:exactMatch	mesh	C000002	bevonium	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135497	eprozinol	skos:exactMatch	mesh	C015853	eprozinol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135500	moperone	skos:exactMatch	mesh	C005209	moperone	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1379,8 +1450,39 @@ chebi	CHEBI:135755	sulprostone	skos:exactMatch	mesh	C016767	sulprostone	manually
 chebi	CHEBI:135756	spirapril	skos:exactMatch	mesh	C052555	spirapril	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135757	edatrexate	skos:exactMatch	mesh	C040210	edatrexate	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135758	tiropramide	skos:exactMatch	mesh	C031173	tiropramide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135760	dibrompropamidine	skos:exactMatch	mesh	C053597	dibrompropamidine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135762	methylprednisolone aceponate	skos:exactMatch	mesh	C078007	methylprednisolone aceponate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135764	mitopodozide	skos:exactMatch	mesh	C003170	mitopodozide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135767	rilmazafone	skos:exactMatch	mesh	C041075	rilmazafone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135768	picloxydine	skos:exactMatch	mesh	C005253	picloxydine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135772	meclocycline	skos:exactMatch	mesh	C100122	meclocycline	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135774	ebrotidine	skos:exactMatch	mesh	C075156	ebrotidine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135775	mosapramine	skos:exactMatch	mesh	C046384	mosapramine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135779	amrubicin	skos:exactMatch	mesh	C055866	amrubicin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135781	fentonium	skos:exactMatch	mesh	C100112	fentonium	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135783	etiprednol dicloacetate	skos:exactMatch	mesh	C450000	etiprednol dicloacetate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135784	imiclopazine	skos:exactMatch	mesh	C002916	imiclopazine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135786	fenoxedil	skos:exactMatch	mesh	C010726	fenoxedil	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135789	neltenexine	skos:exactMatch	mesh	C095919	neltenexine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135790	estriol succinate	skos:exactMatch	mesh	C009341	estriol succinate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135791	prednicarbate	skos:exactMatch	mesh	C035287	prednicarbate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135792	sulisatin	skos:exactMatch	mesh	C012120	sulisatin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135794	bezitramide	skos:exactMatch	mesh	C004461	bezitramide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135795	loperamide oxide	skos:exactMatch	mesh	C066043	loperamide oxide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135797	nicomorphine	skos:exactMatch	mesh	C008549	nicomorphine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135798	betamethasone benzoate	skos:exactMatch	mesh	C015706	betamethasone benzoate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135800	binifibrate	skos:exactMatch	mesh	C038877	binifibrate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135801	clobenoside	skos:exactMatch	mesh	C044699	clobenoside	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135802	tritoqualine	skos:exactMatch	mesh	C003722	tritoqualine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135803	teclozan	skos:exactMatch	mesh	C017951	teclozan	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135805	dexamethasone dipropionate	skos:exactMatch	mesh	C059542	dexamethasone dipropionate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135806	benidipine	skos:exactMatch	mesh	C061004	benidipine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135808	oxaflumazine	skos:exactMatch	mesh	C005286	oxaflumazine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135809	landiolol	skos:exactMatch	mesh	C077049	landiolol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135811	pinaverium	skos:exactMatch	mesh	C013199	pinaverium	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135813	flomoxef	skos:exactMatch	mesh	C045693	flomoxef	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135814	benziodarone	skos:exactMatch	mesh	C058702	benziodarone	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135815	betamethasone butyrate propionate	skos:exactMatch	mesh	C000612965	betamethasone butyrate propionate	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135853	tirilazad	skos:exactMatch	mesh	C053355	tirilazad	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135854	guamecycline	skos:exactMatch	mesh	C001312	guamecycline	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135855	tocofibrate	skos:exactMatch	mesh	C035386	tocofibrate	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1484,9 +1586,29 @@ chebi	CHEBI:30805	dodecanoic acid	skos:exactMatch	mesh	C030358	lauric acid	manua
 chebi	CHEBI:3090	bicalutamide	skos:exactMatch	mesh	C053541	bicalutamide	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:3103	bilobalide	skos:exactMatch	mesh	C073710	bilobalide	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31184	alclometasone dipropionate	skos:exactMatch	mesh	C021137	alclometasone dipropionate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31190	alminoprofen	skos:exactMatch	mesh	C027953	alminoprofen	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31199	amcinonide	skos:exactMatch	mesh	C012716	amcinonide	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31205	amlexanox	skos:exactMatch	mesh	C045742	amlexanox	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31210	ampiroxicam	skos:exactMatch	mesh	C065946	ampiroxicam	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31248	azosemide	skos:exactMatch	mesh	C018222	azosemide	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31249	azulene	skos:exactMatch	mesh	C005525	azulene	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31275	betamethasone acetate	skos:exactMatch	mesh	C580789	betamethasone acetate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:3129	bispyribac	skos:exactMatch	mesh	C549011	bispyribac	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31291	bismuth subcarbonate	skos:exactMatch	mesh	C028508	bismuth subcarbonate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31292	bismuth subgallate	skos:exactMatch	mesh	C002170	bismuth subgallate	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31296	Blonanserin	skos:exactMatch	mesh	C079310	blonanserin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31297	bolandiol dipropionate	skos:exactMatch	mesh	C034533	bolandiol dipropionate	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:3130	bitertanol	skos:exactMatch	mesh	C083642	bitertanol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31319	bufogenin	skos:exactMatch	mesh	C005734	bufogenin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:3133	bitolterol	skos:exactMatch	mesh	C011685	bitolterol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31349	carbazochrome	skos:exactMatch	mesh	C073338	carbazochrome	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31379	cefroxadine	skos:exactMatch	mesh	C012671	cefroxadine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31399	cilnidipine	skos:exactMatch	mesh	C065927	cilnidipine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31426	cloxazolam	skos:exactMatch	mesh	C005522	cloxazolam	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31439	crotamiton	skos:exactMatch	mesh	C005553	crotamiton	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:31501	dimorpholamine	skos:exactMatch	mesh	C100074	dimorpholamine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:315018	echinocandin B	skos:exactMatch	mesh	C007572	echinocandin B	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:315019	cilofungin	skos:exactMatch	mesh	C042101	cilofungin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31549	epothilone A	skos:exactMatch	mesh	C093787	epothilone A	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31550	epothilone B	skos:exactMatch	mesh	C093788	epothilone B	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:31612	Floctafenine	skos:exactMatch	mesh	C084600	floctafenine	manually_reviewed	orcid:0000-0001-9439-5346
@@ -4804,6 +4926,7 @@ mesh	D004031	Diestrus	skos:exactMatch	go	GO:0060207	diestrus	manually_reviewed	o
 mesh	D004063	Digestion	skos:exactMatch	go	GO:0007586	digestion	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004205	Cromolyn Sodium	skos:exactMatch	ncit	C28946	Cromolyn Sodium	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D004241	Diverticulum, Colon	skos:exactMatch	ncit	C34550	Colonic Diverticulum	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004247	DNA	skos:exactMatch	chebi	CHEBI:16991	deoxyribonucleic acid	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004260	DNA Repair	skos:exactMatch	go	GO:0006281	DNA repair	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004261	DNA Replication	skos:exactMatch	go	GO:0006260	DNA replication	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004263	DNA Tumor Viruses	skos:exactMatch	ncit	C14199	DNA Tumor Virus	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5129,6 +5252,7 @@ mesh	D012223	Rhinitis, Vasomotor	skos:exactMatch	ncit	C34988	Vasomotor Rhinitis	
 mesh	D012229	Rhinovirus	skos:exactMatch	ncit	C77200	Rhinovirus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012254	Ribavirin	skos:exactMatch	ncit	C807	Ribavirin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012270	Ribosomes	skos:exactMatch	go	GO:0005840	ribosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012313	RNA	skos:exactMatch	chebi	CHEBI:33697	ribonucleic acid	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012326	RNA Splicing	skos:exactMatch	go	GO:0008380	RNA splicing	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012328	RNA Viruses	skos:exactMatch	ncit	C14269	RNA Virus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D012373	Rocky Mountain Spotted Fever	skos:exactMatch	doid	DOID:0050052	Rocky Mountain spotted fever	manually_reviewed	orcid:0000-0003-1307-2508

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -626,6 +626,8 @@ chebi	CHEBI:10086	Yamogenin	skos:exactMatch	mesh	C514916	yamogenin	manually_revi
 chebi	CHEBI:10089	Yangonin	skos:exactMatch	mesh	C110481	yangonin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10100	zafirlukast	skos:exactMatch	mesh	C062735	zafirlukast	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10102	zaleplon	skos:exactMatch	mesh	C085665	zaleplon	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:101064	Ro 48-8071	skos:exactMatch	mesh	C105726	Ro 48-8071	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:10109	Zexbrevin B	skos:exactMatch	mesh	C010647	zexbrevin B	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10112	zileuton	skos:exactMatch	mesh	C063449	zileuton	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10115	zingiberene	skos:exactMatch	mesh	C477983	zingiberene	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10116	Zinnimidine	skos:exactMatch	mesh	C504969	zinnimidine	manually_reviewed	orcid:0000-0001-9439-5346
@@ -640,11 +642,13 @@ chebi	CHEBI:10136	gingerol	skos:exactMatch	mesh	C007845	gingerol	manually_review
 chebi	CHEBI:1014	2-Aminoadenosine	skos:exactMatch	mesh	C033854	2-aminoadenosine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:102029	sorbinil	skos:exactMatch	mesh	C026411	sorbinil	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10213	alpha-amyrin	skos:exactMatch	mesh	C000654244	alpha-amyrin	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:10219	alpha-Chaconine	skos:exactMatch	mesh	C011860	alpha-chaconine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:102328	6-azathymine	skos:exactMatch	mesh	C039857	6-azathymine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:1026	2-Benzimidazolylguanidine	skos:exactMatch	mesh	C032996	2-benzimidazolylguanidine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10285	alpha-Kosin	skos:exactMatch	mesh	C069975	alpha-kosin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10303	alpha-Methyl-m-tyrosine	skos:exactMatch	mesh	C031476	alpha-methyl-m-tyrosine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10319	1-naphthol	skos:exactMatch	mesh	C029350	1-naphthol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:10324	alpha-peltatin	skos:exactMatch	mesh	C049798	alpha-peltatin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10352	beta-amyrin	skos:exactMatch	mesh	C036380	beta-amyrin	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10423	oleandrose	skos:exactMatch	mesh	C035441	oleandrose	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:10432	2-naphthol	skos:exactMatch	mesh	C028405	2-naphthol	manually_reviewed	orcid:0000-0001-9439-5346
@@ -973,6 +977,7 @@ chebi	CHEBI:134912	methiodal	skos:exactMatch	mesh	C100285	methiodal	manually_rev
 chebi	CHEBI:134915	nicametate	skos:exactMatch	mesh	C005392	nicametate	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134916	mephenoxalone	skos:exactMatch	mesh	C100282	mephenoxalone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134917	rimiterol	skos:exactMatch	mesh	C084590	rimiterol	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:134918	toliprolol	skos:exactMatch	mesh	C073327	toliprolol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134921	nifenalol	skos:exactMatch	mesh	C100250	nifenalol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134923	talbutal	skos:exactMatch	mesh	C446080	talbutal	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:134924	febuprol	skos:exactMatch	mesh	C006281	febuprol	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1155,6 +1160,7 @@ chebi	CHEBI:135239	indobufen	skos:exactMatch	mesh	C020371	indobufen	manually_rev
 chebi	CHEBI:135244	tertatolol	skos:exactMatch	mesh	C005632	tertatolol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135248	bermoprofen	skos:exactMatch	mesh	C040006	bermoprofen	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135252	bentazepam	skos:exactMatch	mesh	C006129	bentazepam	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135254	fenclofenac	skos:exactMatch	mesh	C012970	fenclofenac	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135259	metochalcone	skos:exactMatch	mesh	C003702	metochalcone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135261	carazolol	skos:exactMatch	mesh	C014382	carazolol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135263	methestrol	skos:exactMatch	mesh	C005552	methestrol	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1205,6 +1211,7 @@ chebi	CHEBI:135329	fomocaine	skos:exactMatch	mesh	C100275	fomocain	manually_revi
 chebi	CHEBI:135330	femoxetine	skos:exactMatch	mesh	C010655	femoxetine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135334	pyrrobutamine	skos:exactMatch	mesh	C013665	pyrrobutamine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135335	artemotil	skos:exactMatch	mesh	C055141	artemotil	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135339	demegestone	skos:exactMatch	mesh	C011214	demegestone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135340	benorilate	skos:exactMatch	mesh	C084830	benorilate	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135345	fenalcomine	skos:exactMatch	mesh	C001424	fenalcomine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135347	methopromazine	skos:exactMatch	mesh	C008393	methopromazine	manually_reviewed	orcid:0000-0001-9439-5346
@@ -1215,6 +1222,7 @@ chebi	CHEBI:135354	butalamine	skos:exactMatch	mesh	C067591	butalamine	manually_r
 chebi	CHEBI:135356	calusterone	skos:exactMatch	mesh	C073055	calusterone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135359	denopamine	skos:exactMatch	mesh	C037293	denopamine	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135362	bietamiverine	skos:exactMatch	mesh	C005680	bietamiverine	manually_reviewed	orcid:0000-0001-9439-5346
+chebi	CHEBI:135364	oxetorone	skos:exactMatch	mesh	C011962	oxetorone	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135377	cicloprolol	skos:exactMatch	mesh	C053708	cicloprolol	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135418	oxitropium	skos:exactMatch	mesh	C017590	oxitropium	manually_reviewed	orcid:0000-0001-9439-5346
 chebi	CHEBI:135495	bevonium	skos:exactMatch	mesh	C000002	bevonium	manually_reviewed	orcid:0000-0001-9439-5346


### PR DESCRIPTION
It made some more curations while examining predictions to/from MeSH. @cthoyt I am not entirely sure what happened but a chunk of mappings that are negative diffs in predictions.tsv don't show up as positive diffs in mappings.tsv, one example being 
```
chebi CHEBI:135421 fenalamide skos:exactMatch mesh C004341 fenalamide lexical 0.95 generate_chebi_mesh_mappings.py
```
I possibly messed something up in git manually, though there is also a possibility that the web app had a problem with adding some of the curations. We should sort these out before merging.