### PR TITLE
Curate MONDO-MeSH mappings

### DIFF
--- a/scripts/add_mesh_xrefs_to_mondo.py
+++ b/scripts/add_mesh_xrefs_to_mondo.py
@@ -1,0 +1,68 @@
+"""This script adds newly inferred cross-references for MONDO.
+
+These are added directly to the version controlled MONDO OBO file.
+"""
+
+from biomappings import load_mappings
+
+EDITABLE_OBO_PATH = "/home/ben/src/mondo/src/ontology/mondo-edit.obo"
+
+
+def add_xref(lines, node, xref):
+    """Add xref to OBO file lines in the appropriate place."""
+    look_for_xref = False
+    start_xref_idx = None
+    def_idx = None
+    name_idx = None
+    xref_entries = []
+    for idx, line in enumerate(lines):
+        # If this is the block for the given node, we start looking for xrefs
+        if line == "id: %s\n" % node:
+            look_for_xref = True
+            continue
+        # If we are looking for xrefs
+        elif look_for_xref:
+            # If we find the definition, we save its index
+            if line.startswith("def"):
+                def_idx = idx
+            if line.startswith("name"):
+                name_idx = idx
+            # If we find an xref, we keep track of it
+            if line.startswith("xref"):
+                if not start_xref_idx:
+                    start_xref_idx = idx
+                xref_entries.append(line[6:].strip())
+            # If we've already found some xrefs and then hit a line that
+            # is not an xref, then we are done collecting xrefs
+            if start_xref_idx and not line.startswith("xref"):
+                break
+            # If we then find an empty line, we are at the end of the
+            # OBO entry and never found any xrefs. In this case, we put
+            # the xref after the definition line or the name line
+            if not line.strip():
+                if def_idx:
+                    start_xref_idx = def_idx + 1
+                else:
+                    start_xref_idx = name_idx + 1
+                break
+    xref_entries.append(xref)
+    xref_entries = sorted(xref_entries)
+    xr_idx = xref_entries.index(xref)
+    lines.insert(start_xref_idx + xr_idx, 'xref: %s {source="MONDO:equivalentTo"}\n' % xref)
+    return lines
+
+
+if __name__ == "__main__":
+    mappings = load_mappings()
+    mondo_mappings = [m for m in mappings if m["source prefix"] == "mondo"]
+
+    with open(EDITABLE_OBO_PATH, "r") as fh:
+        lines = fh.readlines()
+
+    for mapping in mondo_mappings:
+        lines = add_xref(
+            lines, mapping["source identifier"], "MESH:" + mapping["target identifier"]
+        )
+
+    with open(EDITABLE_OBO_PATH, "w") as fh:
+        fh.writelines(lines)

--- a/scripts/generate_mondo_mesh_mappings.py
+++ b/scripts/generate_mondo_mesh_mappings.py
@@ -1,0 +1,56 @@
+"""Generate mappings using Gilda from MONDO to MeSH."""
+from collections import Counter
+
+import gilda
+import obonet
+from indra.databases import mesh_client
+
+from biomappings.resources import PredictionTuple, append_prediction_tuples
+
+g = obonet.read_obo("http://purl.obolibrary.org/obo/mondo.obo")
+
+mappings = {}
+existing_refs_to_mesh = set()
+for node, data in g.nodes(data=True):
+    if not node.startswith("MONDO"):
+        continue
+    if 'name' not in data:
+        continue
+    mesh_refs = [xref[5:] for xref in data.get("xref", []) if xref.startswith("MESH")]
+    if mesh_refs:
+        existing_refs_to_mesh |= set(mesh_refs)
+    matches = gilda.ground(data["name"], namespaces=['MESH'])
+    if matches:
+        for grounding in matches[0].get_groundings():
+            if grounding[0] == 'MESH':
+                mappings[node] = matches[0].term.id
+
+print("Found %d MONDO->MESH mappings." % len(mappings))
+
+mappings = {k: v for k, v in mappings.items()
+            if v not in existing_refs_to_mesh}
+
+cnt = Counter(mappings.values())
+
+mappings = {k: v for k, v in mappings.items()
+            if cnt[v] == 1}
+
+print("Found %d MONDO->MESH mappings." % len(mappings))
+
+predictions = []
+for mondo_id, mesh_id in mappings.items():
+    pred = PredictionTuple(
+        source_prefix="mondo",
+        source_id=mondo_id,
+        source_name=g.nodes[mondo_id]["name"],
+        relation="skos:exactMatch",
+        target_prefix="mesh",
+        target_identifier=mesh_id,
+        target_name=mesh_client.get_mesh_name(mesh_id),
+        type="lexical",
+        confidence=0.9,
+        source="generate_mondo_mesh_mappings.py",
+    )
+    predictions.append(pred)
+
+append_prediction_tuples(predictions, deduplicate=True, sort=True)

--- a/scripts/generate_mondo_mesh_mappings.py
+++ b/scripts/generate_mondo_mesh_mappings.py
@@ -13,8 +13,9 @@ from biomappings.resources import PredictionTuple, append_prediction_tuples
 g = obonet.read_obo("http://purl.obolibrary.org/obo/mondo.obo")
 
 
-curated_mappings = {m['source identifier'] for m in load_mappings()
-                    if m['source prefix'] == 'mondo'}
+curated_mappings = {
+    m["source identifier"] for m in load_mappings() if m["source prefix"] == "mondo"
+}
 
 mappings = {}
 existing_refs_to_mesh = set()
@@ -24,15 +25,15 @@ for node, data in g.nodes(data=True):
         continue
     if "name" not in data:
         continue
-    mondo_id = node.split(':', maxsplit=1)[1]
+    mondo_id = node.split(":", maxsplit=1)[1]
     if mondo_id in curated_mappings:
         continue
-    xrefs = [xref.split(':', maxsplit=1) for xref in data.get("xref", [])]
+    xrefs = [xref.split(":", maxsplit=1) for xref in data.get("xref", [])]
     xrefs_dict = fix_invalidities_db_refs(dict(xrefs))
     standard_refs = standardize_db_refs(xrefs_dict)
-    if 'MESH' in standard_refs:
+    if "MESH" in standard_refs:
         already_mappable.add(node)
-    existing_refs_to_mesh |= {id for ns, id in standard_refs.items() if ns == 'MESH'}
+    existing_refs_to_mesh |= {id for ns, id in standard_refs.items() if ns == "MESH"}
     matches = gilda.ground(data["name"], namespaces=["MESH"])
     if matches:
         for grounding in matches[0].get_groundings():
@@ -42,8 +43,11 @@ for node, data in g.nodes(data=True):
 
 print("Found %d MONDO->MESH mappings." % len(mappings))
 
-mappings = {k: v for k, v in mappings.items() if v not in existing_refs_to_mesh
-            and k not in already_mappable}
+mappings = {
+    k: v
+    for k, v in mappings.items()
+    if v not in existing_refs_to_mesh and k not in already_mappable
+}
 
 cnt = Counter(mappings.values())
 

--- a/scripts/generate_mondo_mesh_mappings.py
+++ b/scripts/generate_mondo_mesh_mappings.py
@@ -5,6 +5,7 @@ import gilda
 import obonet
 from indra.databases import mesh_client
 from indra.ontology.standardize import standardize_db_refs
+from indra.tools.fix_invalidities import fix_invalidities_db_refs
 
 from biomappings import load_mappings
 from biomappings.resources import PredictionTuple, append_prediction_tuples
@@ -27,7 +28,7 @@ for node, data in g.nodes(data=True):
     if mondo_id in curated_mappings:
         continue
     xrefs = [xref.split(':', maxsplit=1) for xref in data.get("xref", [])]
-    xrefs_dict = dict(xrefs)
+    xrefs_dict = fix_invalidities_db_refs(dict(xrefs))
     standard_refs = standardize_db_refs(xrefs_dict)
     if 'MESH' in standard_refs:
         already_mappable.add(node)

--- a/scripts/generate_mondo_mesh_mappings.py
+++ b/scripts/generate_mondo_mesh_mappings.py
@@ -14,26 +14,24 @@ existing_refs_to_mesh = set()
 for node, data in g.nodes(data=True):
     if not node.startswith("MONDO"):
         continue
-    if 'name' not in data:
+    if "name" not in data:
         continue
     mesh_refs = [xref[5:] for xref in data.get("xref", []) if xref.startswith("MESH")]
     if mesh_refs:
         existing_refs_to_mesh |= set(mesh_refs)
-    matches = gilda.ground(data["name"], namespaces=['MESH'])
+    matches = gilda.ground(data["name"], namespaces=["MESH"])
     if matches:
         for grounding in matches[0].get_groundings():
-            if grounding[0] == 'MESH':
+            if grounding[0] == "MESH":
                 mappings[node] = matches[0].term.id
 
 print("Found %d MONDO->MESH mappings." % len(mappings))
 
-mappings = {k: v for k, v in mappings.items()
-            if v not in existing_refs_to_mesh}
+mappings = {k: v for k, v in mappings.items() if v not in existing_refs_to_mesh}
 
 cnt = Counter(mappings.values())
 
-mappings = {k: v for k, v in mappings.items()
-            if cnt[v] == 1}
+mappings = {k: v for k, v in mappings.items() if cnt[v] == 1}
 
 print("Found %d MONDO->MESH mappings." % len(mappings))
 
@@ -41,7 +39,7 @@ predictions = []
 for mondo_id, mesh_id in mappings.items():
     pred = PredictionTuple(
         source_prefix="mondo",
-        source_id=mondo_id,
+        source_id=mondo_id[6:],
         source_name=g.nodes[mondo_id]["name"],
         relation="skos:exactMatch",
         target_prefix="mesh",

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -540,11 +540,11 @@ mesh	D065627	Familial Primary Pulmonary Hypertension	skos:exactMatch	doid	DOID:1
 mesh	D065637	Cytochrome P-450 CYP2A6	skos:exactMatch	hgnc	2610	CYP2A6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D066167	Slit Lamp	skos:exactMatch	ncit	C75583	Slit-lamp Examination	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066246	ErbB Receptors	skos:exactMatch	ncit	C17068	Epidermal Growth Factor Receptor	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0005187	human herpesvirus 8 infection	skos:exactMatch	mesh	D019288	Herpesvirus 8, Human	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015053	hereditary angioedema type 1	skos:exactMatch	mesh	D056829	Hereditary Angioedema Types I and II	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0020320	acute myeloblastic leukemia with maturation	skos:exactMatch	mesh	D000650	Amnion	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0044346	echinococcus granulosus infectious disease	skos:exactMatch	mesh	D048209	Echinococcus granulosus	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100073	methicillin-resistant staphylococcus aureus infectious disease	skos:exactMatch	mesh	D055624	Methicillin-Resistant Staphylococcus aureus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0005187	human herpesvirus 8 infection	skos:exactMatch	mesh	D019288	Herpesvirus 8, Human	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015053	hereditary angioedema type 1	skos:exactMatch	mesh	D056829	Hereditary Angioedema Types I and II	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020320	acute myeloblastic leukemia with maturation	skos:exactMatch	mesh	D000650	Amnion	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0044346	echinococcus granulosus infectious disease	skos:exactMatch	mesh	D048209	Echinococcus granulosus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100073	methicillin-resistant staphylococcus aureus infectious disease	skos:exactMatch	mesh	D055624	Methicillin-Resistant Staphylococcus aureus	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035716	ubiquitin (RPS27A)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035720	ubiquitin (UBC)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035722	ubiquitin (UBA52)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -541,6 +541,10 @@ mesh	D065637	Cytochrome P-450 CYP2A6	skos:exactMatch	hgnc	2610	CYP2A6	manually_r
 mesh	D066167	Slit Lamp	skos:exactMatch	ncit	C75583	Slit-lamp Examination	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066246	ErbB Receptors	skos:exactMatch	ncit	C17068	Epidermal Growth Factor Receptor	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0005187	human herpesvirus 8 infection	skos:exactMatch	mesh	D019288	Herpesvirus 8, Human	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015053	hereditary angioedema type 1	skos:exactMatch	mesh	D056829	Hereditary Angioedema Types I and II	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0020320	acute myeloblastic leukemia with maturation	skos:exactMatch	mesh	D000650	Amnion	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0044346	echinococcus granulosus infectious disease	skos:exactMatch	mesh	D048209	Echinococcus granulosus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100073	methicillin-resistant staphylococcus aureus infectious disease	skos:exactMatch	mesh	D055624	Methicillin-Resistant Staphylococcus aureus	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035716	ubiquitin (RPS27A)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035720	ubiquitin (UBC)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035722	ubiquitin (UBA52)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -540,6 +540,7 @@ mesh	D065627	Familial Primary Pulmonary Hypertension	skos:exactMatch	doid	DOID:1
 mesh	D065637	Cytochrome P-450 CYP2A6	skos:exactMatch	hgnc	2610	CYP2A6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D066167	Slit Lamp	skos:exactMatch	ncit	C75583	Slit-lamp Examination	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066246	ErbB Receptors	skos:exactMatch	ncit	C17068	Epidermal Growth Factor Receptor	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0005187	human herpesvirus 8 infection	skos:exactMatch	mesh	D019288	Herpesvirus 8, Human	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035716	ubiquitin (RPS27A)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035720	ubiquitin (UBC)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000035722	ubiquitin (UBA52)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -6447,6 +6447,106 @@ mesh	D066270	Social Capital	skos:exactMatch	ncit	C93209	Social Capital	manually_
 mesh	D066271	External Capsule	skos:exactMatch	ncit	C32550	External Capsule	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066292	Lipid Droplets	skos:exactMatch	go	GO:0005811	lipid droplet	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066293	Renshaw Cells	skos:exactMatch	ncit	C33463	Renshaw Cell	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000158	developmental dysplasia of the hip	skos:exactMatch	mesh	D000082602	Developmental Dysplasia of the Hip	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000239	adiaspiromycosis	skos:exactMatch	mesh	C000656784	adiaspiromycosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000242	tinea barbae	skos:exactMatch	mesh	C000656825	tinea barbae	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000455	cone dystrophy	skos:exactMatch	mesh	D000077765	Cone Dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000598	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000716	agraphia	skos:exactMatch	mesh	D000381	Agraphia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000819	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001020	amblyopia	skos:exactMatch	mesh	D000550	Amblyopia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001045	intestinal atresia	skos:exactMatch	mesh	D007409	Intestinal Atresia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001134	essential hypertension	skos:exactMatch	mesh	D000075222	Essential Hypertension	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001149	microcephaly	skos:exactMatch	mesh	D008831	Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001247	social phobia	skos:exactMatch	mesh	D000072861	Phobia, Social	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001357	hypochromic anemia	skos:exactMatch	mesh	D000747	Anemia, Hypochromic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic Neuropathy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016217	mal de Debarquement	skos:exactMatch	mesh	C537840	Mal de debarquement	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016295	neuronal ceroid lipofuscinosis	skos:exactMatch	mesh	D009472	Neuronal Ceroid-Lipofuscinoses	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016301	congenitally corrected transposition of the great arteries	skos:exactMatch	mesh	D000080041	Congenitally Corrected Transposition of the Great Arteries	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016567	locked-in syndrome	skos:exactMatch	mesh	D000080422	Locked-In Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016607	odontohypophosphatasia	skos:exactMatch	mesh	C564146	Odontohypophosphatasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016798	ataxia neuropathy spectrum	skos:exactMatch	mesh	C579922	Ataxia Neuropathy Spectrum	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016809	spinocerebellar ataxia with epilepsy	skos:exactMatch	mesh	C564395	Spinocerebellar Ataxia with Epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017161	frontotemporal dementia with motor neuron disease	skos:exactMatch	mesh	C566288	Frontotemporal Dementia With Motor Neuron Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017169	multiple endocrine neoplasia	skos:exactMatch	mesh	D009377	Multiple Endocrine Neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017198	osteopetrosis	skos:exactMatch	mesh	D010022	Osteopetrosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017267	self-healing collodion baby	skos:exactMatch	mesh	C565473	Self-Healing Collodion Baby	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017349	myopericytoma	skos:exactMatch	mesh	D000077777	Myopericytoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017999	fatty acid hydroxylase-associated neurodegeneration	skos:exactMatch	mesh	C580102	Fatty Acid Hydroxylase-Associated Neurodegeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018082	aorto-ventricular tunnel	skos:exactMatch	mesh	D000082903	Aortico-Ventricular Tunnel	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018135	oculocutaneous albinism type 1	skos:exactMatch	mesh	C537728	Oculocutaneous albinism type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018154	Madelung deformity	skos:exactMatch	mesh	C562398	Madelung Deformity	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018338	activated PI3K-delta syndrome	skos:exactMatch	mesh	C585640	Activated PI3K-delta Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018363	focal facial dermal dysplasia	skos:exactMatch	mesh	C537068	Focal facial dermal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018668	scedosporiosis	skos:exactMatch	mesh	C000656924	scedosporiosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018815	aneurysmal bone cyst	skos:exactMatch	mesh	D017824	Bone Cysts, Aneurysmal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018830	Kimura disease	skos:exactMatch	mesh	D000082242	Kimura Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018869	cobblestone lissencephaly	skos:exactMatch	mesh	D054222	Cobblestone Lissencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018878	branchiootic syndrome	skos:exactMatch	mesh	C537104	Branchiootic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018949	distal myopathy	skos:exactMatch	mesh	D049310	Distal Myopathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019107	Rh deficiency syndrome	skos:exactMatch	mesh	C562717	Rh Deficiency Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019155	Leydig cell hypoplasia	skos:exactMatch	mesh	C562567	Leydig Cell Hypoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019169	pyruvate dehydrogenase deficiency	skos:exactMatch	mesh	D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019353	Stargardt disease	skos:exactMatch	mesh	D000080362	Stargardt Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019669	hypochondrogenesis	skos:exactMatch	mesh	C563007	Hypochondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Terminal Transverse Defects of Arm	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020806	sinoatrial block	skos:exactMatch	mesh	D012848	Sinoatrial Block	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021065	pleural neoplasm	skos:exactMatch	mesh	D010997	Pleural Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021092	fallopian tube neoplasm	skos:exactMatch	mesh	D005185	Fallopian Tube Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021106	laminopathy	skos:exactMatch	mesh	D000083083	Laminopathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021224	iris neoplasm	skos:exactMatch	mesh	D015811	Iris Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021234	spinal cord neoplasm	skos:exactMatch	mesh	D013120	Spinal Cord Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021253	gallbladder neoplasm	skos:exactMatch	mesh	D005706	Gallbladder Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021662	bile duct neoplasm	skos:exactMatch	mesh	D001650	Bile Duct Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0022140	Charles bonnet syndrome	skos:exactMatch	mesh	D000075562	Charles Bonnet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0022208	crystal arthropathy	skos:exactMatch	mesh	D000070657	Crystal Arthropathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0023305	heavy metal poisoning	skos:exactMatch	mesh	D000075322	Heavy Metal Poisoning	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024264	hypothyroidism, congenital, nongoitrous, 2	skos:exactMatch	mesh	C566852	Hypothyroidism, Congenital, Nongoitrous, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024288	hyperbilirubinemia	skos:exactMatch	mesh	D006932	Hyperbilirubinemia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024332	perennial allergic rhinitis	skos:exactMatch	mesh	D012221	Rhinitis, Allergic, Perennial	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024361	circadian rhythm sleep disorder	skos:exactMatch	mesh	D020178	Sleep Disorders, Circadian Rhythm	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024465	surfactant metabolism dysfunction, pulmonary, 2	skos:exactMatch	mesh	C567048	Surfactant Metabolism Dysfunction, Pulmonary, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024559	aortic aneurysm, familial thoracic 1	skos:exactMatch	mesh	C562834	Aortic Aneurysm, Familial Thoracic 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024647	urolithiasis	skos:exactMatch	mesh	D052878	Urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024653	skull neoplasm	skos:exactMatch	mesh	D012888	Skull Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0026404	X inactivation, familial skewed, 1	skos:exactMatch	mesh	C564716	X Inactivation, Familial Skewed, 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0026426	X inactivation, familial skewed, 2	skos:exactMatch	mesh	C564572	X Inactivation, Familial Skewed, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0027091	xanthogranulomatous sialadenitis	skos:exactMatch	mesh	C536763	Xanthogranulomatous sialadenitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0030048	harderoporphyria	skos:exactMatch	mesh	C562816	Harderoporphyria	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0036591	adrenal cortex neoplasm	skos:exactMatch	mesh	D000306	Adrenal Cortex Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0037748	hyperlipoproteinemia	skos:exactMatch	mesh	D006951	Hyperlipoproteinemias	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041161	endometrial hyperplasia	skos:exactMatch	mesh	D004714	Endometrial Hyperplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041656	ST-elevation myocardial infarction	skos:exactMatch	mesh	D000072657	ST Elevation Myocardial Infarction	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041751	multibacillary leprosy	skos:exactMatch	mesh	D056006	Leprosy, Multibacillary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041752	paucibacillary leprosy	skos:exactMatch	mesh	D056005	Leprosy, Paucibacillary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0044877	paraneoplastic cerebellar degeneration	skos:exactMatch	mesh	D020362	Paraneoplastic Cerebellar Degeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0054868	meconium ileus	skos:exactMatch	mesh	D000074270	Meconium Ileus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100053	anaphylaxis	skos:exactMatch	mesh	D000707	Anaphylaxis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100075	jaw fracture	skos:exactMatch	mesh	D007572	Jaw Fractures	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100115	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100120	vector-borne disease	skos:exactMatch	mesh	D000079426	Vector Borne Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100128	coinfection	skos:exactMatch	mesh	D060085	Coinfection	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100164	permanent neonatal diabetes mellitus	skos:exactMatch	mesh	C563425	Diabetes Mellitus, Permanent Neonatal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100192	liver failure	skos:exactMatch	mesh	D017093	Liver Failure	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100338	urinary tract infection	skos:exactMatch	mesh	D014552	Urinary Tract Infections	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100345	lactose intolerance	skos:exactMatch	mesh	D007787	Lactose Intolerance	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100350	neuronopathy, distal hereditary motor, type 5	skos:exactMatch	mesh	C563443	Neuronopathy, Distal Hereditary Motor, Type V	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100457	achalasia, familial esophageal	skos:exactMatch	mesh	C536011	Achalasia, familial esophageal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100482	extensively drug-resistant tuberculosis	skos:exactMatch	mesh	D054908	Extensively Drug-Resistant Tuberculosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0400005	refeeding syndrome	skos:exactMatch	mesh	D055677	Refeeding Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0600008	cytokine release syndrome	skos:exactMatch	mesh	D000080424	Cytokine Release Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0700064	aneuploidy	skos:exactMatch	mesh	D000782	Aneuploidy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0700065	trisomy	skos:exactMatch	mesh	D014314	Trisomy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0700086	uniparental disomy	skos:exactMatch	mesh	D024182	Uniparental Disomy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:8000018	benign paroxysmal positional vertigo	skos:exactMatch	mesh	D065635	Benign Paroxysmal Positional Vertigo	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:8000019	vertigo, benign recurrent, 1	skos:exactMatch	mesh	C567620	Vertigo, Benign Recurrent, 1	manually_reviewed	orcid:0000-0001-9439-5346
 ncit	C1707	Voriconazole	skos:exactMatch	chebi	CHEBI:10023	voriconazole	manual	orcid:0000-0003-4423-4370
 ncit	C2160	Proteasome Inhibitor	skos:exactMatch	chebi	CHEBI:52726	proteasome inhibitor	manual	orcid:0000-0003-4423-4370
 ncit	C65538	Esomeprazole	skos:exactMatch	chebi	CHEBI:50275	esomeprazole	manual	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -6461,6 +6461,65 @@ mondo	0001149	microcephaly	skos:exactMatch	mesh	D008831	Microcephaly	manually_re
 mondo	0001247	social phobia	skos:exactMatch	mesh	D000072861	Phobia, Social	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0001357	hypochromic anemia	skos:exactMatch	mesh	D000747	Anemia, Hypochromic	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic Neuropathy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0002012	methylmalonic acidemia	skos:exactMatch	mesh	C537358	Methylmalonic acidemia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0002648	mammary Paget disease	skos:exactMatch	mesh	D010144	Paget's Disease, Mammary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0005607	chronic bronchitis	skos:exactMatch	mesh	D029481	Bronchitis, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007082	alopecia areata 1	skos:exactMatch	mesh	C566303	Alopecia Areata 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007088	Alzheimer disease type 1	skos:exactMatch	mesh	C536594	Alzheimer disease type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007110	Diamond-Blackfan anemia 1	skos:exactMatch	mesh	C567302	Diamond-Blackfan Anemia 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007329	cirrhosis, familial	skos:exactMatch	mesh	C566123	Cirrhosis, Familial	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007390	coumarin resistance	skos:exactMatch	mesh	C563039	Coumarin Resistance	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007440	major affective disorder 1	skos:exactMatch	mesh	C565111	Major Affective Disorder 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007459	dilution, pigmentary	skos:exactMatch	mesh	C566872	Dilution, Pigmentary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007547	epidermoid cysts	skos:exactMatch	mesh	D004814	Epidermal Cyst	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007578	esterase B	skos:exactMatch	mesh	C049262	esterase B	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007909	familial multiple lipomatosis	skos:exactMatch	mesh	D000071070	Familial Multiple Lipomatosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007942	Mammastatin	skos:exactMatch	mesh	C060120	mammastatin	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008062	narcolepsy 1	skos:exactMatch	mesh	C563534	Narcolepsy 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008163	otofaciocervical syndrome	skos:exactMatch	mesh	C563481	Otofaciocervical Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008197	parietal foramina 1	skos:exactMatch	mesh	C566827	Parietal Foramina 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008273	actinic prurigo	skos:exactMatch	mesh	C566780	Actinic Prurigo	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008328	glaucoma 1, open angle, P	skos:exactMatch	mesh	C566748	Glaucoma 1, Open Angle, P	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008527	tarsal coalition	skos:exactMatch	mesh	D000070604	Tarsal Coalition	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008597	trichorhinophalangeal syndrome, type III	skos:exactMatch	mesh	C566033	Trichorhinophalangeal Syndrome, Type III	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008612	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008734	adrenocortical carcinoma, hereditary	skos:exactMatch	mesh	C565972	Adrenocortical Carcinoma, Hereditary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008738	aganglionosis, total intestinal	skos:exactMatch	mesh	C538058	Aganglionosis, total intestinal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009003	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009175	eosinophilic fasciitis	skos:exactMatch	mesh	C562487	Eosinophilic Fasciitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009202	Thakker-Donnai syndrome	skos:exactMatch	mesh	C536503	Thakker Donnai syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009220	visceral steatosis, congenital	skos:exactMatch	mesh	C536351	Visceral Steatosis, Congenital	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009488	keratoconus posticus circumscriptus	skos:exactMatch	mesh	C536151	Keratoconus posticus circumscriptus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009503	pyruvate dehydrogenase E3-binding protein deficiency	skos:exactMatch	mesh	C565447	Pyruvate Dehydrogenase E3-Binding Protein Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009526	fibular aplasia, tibial campomelia, and oligosyndactyly syndrome	skos:exactMatch	mesh	C565436	Fibular Aplasia, Tibial Campomelia, and Oligosyndactyly Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009573	megaepiphyseal dwarfism	skos:exactMatch	mesh	C536140	Megaepiphyseal dwarfism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009612	methylmalonic aciduria due to methylmalonyl-CoA mutase deficiency	skos:exactMatch	mesh	C565390	Methylmalonic Aciduria due to Methylmalonyl-CoA Mutase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009630	microphthalmia, isolated, with coloboma 4	skos:exactMatch	mesh	C565378	Microphthalmia, Isolated, with Coloboma 4	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009649	moyamoya disease 1	skos:exactMatch	mesh	C536991	Moyamoya disease 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009703	myopathy with abnormal lipid metabolism	skos:exactMatch	mesh	C562935	Myopathy with Abnormal Lipid Metabolism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009766	oculocerebral hypopigmentation syndrome of Preus	skos:exactMatch	mesh	C537866	Oculocerebral hypopigmentation syndrome type Preus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009853	Imerslund-Grasbeck syndrome	skos:exactMatch	mesh	C538556	Imerslund-Grasbeck syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009878	pituitary hormone deficiency, combined, 2	skos:exactMatch	mesh	C563172	Pituitary Hormone Deficiency, Combined, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010056	spinal muscular atrophy, type IV	skos:exactMatch	mesh	C563948	Spinal Muscular Atrophy, Type IV	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010103	teeth, fused	skos:exactMatch	mesh	D005671	Fused Teeth	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010131	thyroid hormone resistance, generalized, autosomal recessive	skos:exactMatch	mesh	C567936	Thyroid Hormone Resistance, Generalized, Autosomal Recessive	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010186	vitamin D-dependent rickets, type 2A	skos:exactMatch	mesh	C562794	Vitamin D-Dependent Rickets, Type 2A	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010201	Winchester syndrome	skos:exactMatch	mesh	C536709	Winchester syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010261	microphthalmia, syndromic 2	skos:exactMatch	mesh	C537465	Microphthalmia, syndromic 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010391	angioma serpiginosum, X-linked	skos:exactMatch	mesh	C536366	Angioma serpiginosum, X-linked	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010535	Bazex-Dupre-Christol syndrome	skos:exactMatch	mesh	C537663	Bazex-Dupre-Christol syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010623	ichthyosis and male hypogonadism	skos:exactMatch	mesh	C537365	Ichthyosis and male hypogonadism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010693	nystagmus 1, congenital, X-linked	skos:exactMatch	mesh	C537853	Nystagmus 1, congenital, X- linked	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010717	pyruvate dehydrogenase E1-alpha deficiency	skos:exactMatch	mesh	C564071	Pyruvate Dehydrogenase E1 Alpha Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010743	thrombocytopenia 1	skos:exactMatch	mesh	C564052	Thrombocytopenia 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010760	XH antigen	skos:exactMatch	mesh	C009691	Xh antigen	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011042	Martinez-Frias syndrome	skos:exactMatch	mesh	C563346	Martinez-Frias Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011120	neural tube defects, folate-sensitive	skos:exactMatch	mesh	C536409	Neural tube defect, folate-sensitive	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011544	paragangliomas 3	skos:exactMatch	mesh	C565335	Paragangliomas 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011713	melanoma-pancreatic cancer syndrome	skos:exactMatch	mesh	C563985	Melanoma-Pancreatic Cancer Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011826	glucocorticoid deficiency 2	skos:exactMatch	mesh	C564577	Glucocorticoid Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011885	tubulointerstitial nephritis and uveitis syndrome	skos:exactMatch	mesh	C536922	Tubulointerstitial nephritis and uveitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0011918	anxiety	skos:exactMatch	mesh	D001007	Anxiety	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -6464,6 +6464,8 @@ mondo	0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic
 mondo	0002012	methylmalonic acidemia	skos:exactMatch	mesh	C537358	Methylmalonic acidemia	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0002648	mammary Paget disease	skos:exactMatch	mesh	D010144	Paget's Disease, Mammary	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0005607	chronic bronchitis	skos:exactMatch	mesh	D029481	Bronchitis, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0006033	diffuse intrinsic pontine glioma	skos:exactMatch	mesh	D000080443	Diffuse Intrinsic Pontine Glioma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0006094	Askin tumor	skos:exactMatch	mesh	C563168	Askin Tumor	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007082	alopecia areata 1	skos:exactMatch	mesh	C566303	Alopecia Areata 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007088	Alzheimer disease type 1	skos:exactMatch	mesh	C536594	Alzheimer disease type 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007110	Diamond-Blackfan anemia 1	skos:exactMatch	mesh	C567302	Diamond-Blackfan Anemia 1	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6473,6 +6475,7 @@ mondo	0007440	major affective disorder 1	skos:exactMatch	mesh	C565111	Major Affe
 mondo	0007459	dilution, pigmentary	skos:exactMatch	mesh	C566872	Dilution, Pigmentary	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007547	epidermoid cysts	skos:exactMatch	mesh	D004814	Epidermal Cyst	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007578	esterase B	skos:exactMatch	mesh	C049262	esterase B	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0007817	IgE responsiveness, atopic	skos:exactMatch	mesh	C564133	Ige Responsiveness, Atopic	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007909	familial multiple lipomatosis	skos:exactMatch	mesh	D000071070	Familial Multiple Lipomatosis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0007942	Mammastatin	skos:exactMatch	mesh	C060120	mammastatin	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008062	narcolepsy 1	skos:exactMatch	mesh	C563534	Narcolepsy 1	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6480,15 +6483,18 @@ mondo	0008163	otofaciocervical syndrome	skos:exactMatch	mesh	C563481	Otofaciocer
 mondo	0008197	parietal foramina 1	skos:exactMatch	mesh	C566827	Parietal Foramina 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008273	actinic prurigo	skos:exactMatch	mesh	C566780	Actinic Prurigo	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008328	glaucoma 1, open angle, P	skos:exactMatch	mesh	C566748	Glaucoma 1, Open Angle, P	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0008426	Shprintzen-Goldberg syndrome	skos:exactMatch	mesh	C537328	Shprintzen Golberg craniosynostosis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008527	tarsal coalition	skos:exactMatch	mesh	D000070604	Tarsal Coalition	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008597	trichorhinophalangeal syndrome, type III	skos:exactMatch	mesh	C566033	Trichorhinophalangeal Syndrome, Type III	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008612	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008734	adrenocortical carcinoma, hereditary	skos:exactMatch	mesh	C565972	Adrenocortical Carcinoma, Hereditary	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0008738	aganglionosis, total intestinal	skos:exactMatch	mesh	C538058	Aganglionosis, total intestinal	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009003	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009130	Dyggve-Melchior-Clausen disease	skos:exactMatch	mesh	C535726	Dyggve-Melchior-Clausen syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009175	eosinophilic fasciitis	skos:exactMatch	mesh	C562487	Eosinophilic Fasciitis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009202	Thakker-Donnai syndrome	skos:exactMatch	mesh	C536503	Thakker Donnai syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009220	visceral steatosis, congenital	skos:exactMatch	mesh	C536351	Visceral Steatosis, Congenital	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0009263	gapo syndrome	skos:exactMatch	mesh	C535642	Growth retardation, Alopecia, Pseudoanodontia and Optic atrophy	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009488	keratoconus posticus circumscriptus	skos:exactMatch	mesh	C536151	Keratoconus posticus circumscriptus	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009503	pyruvate dehydrogenase E3-binding protein deficiency	skos:exactMatch	mesh	C565447	Pyruvate Dehydrogenase E3-Binding Protein Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0009526	fibular aplasia, tibial campomelia, and oligosyndactyly syndrome	skos:exactMatch	mesh	C565436	Fibular Aplasia, Tibial Campomelia, and Oligosyndactyly Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6509,6 +6515,7 @@ mondo	0010261	microphthalmia, syndromic 2	skos:exactMatch	mesh	C537465	Microphth
 mondo	0010391	angioma serpiginosum, X-linked	skos:exactMatch	mesh	C536366	Angioma serpiginosum, X-linked	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0010535	Bazex-Dupre-Christol syndrome	skos:exactMatch	mesh	C537663	Bazex-Dupre-Christol syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0010623	ichthyosis and male hypogonadism	skos:exactMatch	mesh	C537365	Ichthyosis and male hypogonadism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0010644	proteinuria, low molecular weight, with hypercalciuria and nephrocalcinosis	skos:exactMatch	mesh	C545036	Low Molecular Weight Proteinuria with Hypercalciuria and Nephrocalcinosis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0010693	nystagmus 1, congenital, X-linked	skos:exactMatch	mesh	C537853	Nystagmus 1, congenital, X- linked	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0010717	pyruvate dehydrogenase E1-alpha deficiency	skos:exactMatch	mesh	C564071	Pyruvate Dehydrogenase E1 Alpha Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0010743	thrombocytopenia 1	skos:exactMatch	mesh	C564052	Thrombocytopenia 1	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6520,6 +6527,7 @@ mondo	0011713	melanoma-pancreatic cancer syndrome	skos:exactMatch	mesh	C563985	M
 mondo	0011826	glucocorticoid deficiency 2	skos:exactMatch	mesh	C564577	Glucocorticoid Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0011885	tubulointerstitial nephritis and uveitis syndrome	skos:exactMatch	mesh	C536922	Tubulointerstitial nephritis and uveitis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0011918	anxiety	skos:exactMatch	mesh	D001007	Anxiety	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012164	Meacham syndrome	skos:exactMatch	mesh	C538162	Meacham Winn Culler syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0012214	glucocorticoid deficiency 3	skos:exactMatch	mesh	C563776	Glucocorticoid Deficiency 3	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0012217	Bruck syndrome 2	skos:exactMatch	mesh	C537407	Bruck syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0012252	rhabdoid tumor predisposition syndrome 1	skos:exactMatch	mesh	C563738	Rhabdoid Tumor Predisposition Syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6583,6 +6591,7 @@ mondo	0019669	hypochondrogenesis	skos:exactMatch	mesh	C563007	Hypochondrogenesis
 mondo	0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Terminal Transverse Defects of Arm	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0020110	pulmonary agenesis	skos:exactMatch	mesh	C562992	Lung agenesis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0020756	migraine, familial hemiplegic, 1	skos:exactMatch	mesh	C536890	Hemiplegic migraine, familial type 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0020792	dwarfism with tall vertebrae	skos:exactMatch	mesh	C535725	Dwarfism tall vertebrae	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -6447,207 +6447,207 @@ mesh	D066270	Social Capital	skos:exactMatch	ncit	C93209	Social Capital	manually_
 mesh	D066271	External Capsule	skos:exactMatch	ncit	C32550	External Capsule	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066292	Lipid Droplets	skos:exactMatch	go	GO:0005811	lipid droplet	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066293	Renshaw Cells	skos:exactMatch	ncit	C33463	Renshaw Cell	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000158	developmental dysplasia of the hip	skos:exactMatch	mesh	D000082602	Developmental Dysplasia of the Hip	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000239	adiaspiromycosis	skos:exactMatch	mesh	C000656784	adiaspiromycosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000242	tinea barbae	skos:exactMatch	mesh	C000656825	tinea barbae	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000455	cone dystrophy	skos:exactMatch	mesh	D000077765	Cone Dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000598	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000716	agraphia	skos:exactMatch	mesh	D000381	Agraphia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0000819	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001020	amblyopia	skos:exactMatch	mesh	D000550	Amblyopia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001045	intestinal atresia	skos:exactMatch	mesh	D007409	Intestinal Atresia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001134	essential hypertension	skos:exactMatch	mesh	D000075222	Essential Hypertension	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001149	microcephaly	skos:exactMatch	mesh	D008831	Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001247	social phobia	skos:exactMatch	mesh	D000072861	Phobia, Social	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001357	hypochromic anemia	skos:exactMatch	mesh	D000747	Anemia, Hypochromic	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic Neuropathy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0002012	methylmalonic acidemia	skos:exactMatch	mesh	C537358	Methylmalonic acidemia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0002648	mammary Paget disease	skos:exactMatch	mesh	D010144	Paget's Disease, Mammary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0005607	chronic bronchitis	skos:exactMatch	mesh	D029481	Bronchitis, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0006033	diffuse intrinsic pontine glioma	skos:exactMatch	mesh	D000080443	Diffuse Intrinsic Pontine Glioma	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0006094	Askin tumor	skos:exactMatch	mesh	C563168	Askin Tumor	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007082	alopecia areata 1	skos:exactMatch	mesh	C566303	Alopecia Areata 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007088	Alzheimer disease type 1	skos:exactMatch	mesh	C536594	Alzheimer disease type 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007110	Diamond-Blackfan anemia 1	skos:exactMatch	mesh	C567302	Diamond-Blackfan Anemia 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007329	cirrhosis, familial	skos:exactMatch	mesh	C566123	Cirrhosis, Familial	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007390	coumarin resistance	skos:exactMatch	mesh	C563039	Coumarin Resistance	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007440	major affective disorder 1	skos:exactMatch	mesh	C565111	Major Affective Disorder 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007459	dilution, pigmentary	skos:exactMatch	mesh	C566872	Dilution, Pigmentary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007547	epidermoid cysts	skos:exactMatch	mesh	D004814	Epidermal Cyst	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007578	esterase B	skos:exactMatch	mesh	C049262	esterase B	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007817	IgE responsiveness, atopic	skos:exactMatch	mesh	C564133	Ige Responsiveness, Atopic	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007909	familial multiple lipomatosis	skos:exactMatch	mesh	D000071070	Familial Multiple Lipomatosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0007942	Mammastatin	skos:exactMatch	mesh	C060120	mammastatin	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008062	narcolepsy 1	skos:exactMatch	mesh	C563534	Narcolepsy 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008163	otofaciocervical syndrome	skos:exactMatch	mesh	C563481	Otofaciocervical Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008197	parietal foramina 1	skos:exactMatch	mesh	C566827	Parietal Foramina 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008273	actinic prurigo	skos:exactMatch	mesh	C566780	Actinic Prurigo	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008328	glaucoma 1, open angle, P	skos:exactMatch	mesh	C566748	Glaucoma 1, Open Angle, P	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008426	Shprintzen-Goldberg syndrome	skos:exactMatch	mesh	C537328	Shprintzen Golberg craniosynostosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008527	tarsal coalition	skos:exactMatch	mesh	D000070604	Tarsal Coalition	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008597	trichorhinophalangeal syndrome, type III	skos:exactMatch	mesh	C566033	Trichorhinophalangeal Syndrome, Type III	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008612	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008734	adrenocortical carcinoma, hereditary	skos:exactMatch	mesh	C565972	Adrenocortical Carcinoma, Hereditary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0008738	aganglionosis, total intestinal	skos:exactMatch	mesh	C538058	Aganglionosis, total intestinal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009003	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009130	Dyggve-Melchior-Clausen disease	skos:exactMatch	mesh	C535726	Dyggve-Melchior-Clausen syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009175	eosinophilic fasciitis	skos:exactMatch	mesh	C562487	Eosinophilic Fasciitis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009202	Thakker-Donnai syndrome	skos:exactMatch	mesh	C536503	Thakker Donnai syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009220	visceral steatosis, congenital	skos:exactMatch	mesh	C536351	Visceral Steatosis, Congenital	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009263	gapo syndrome	skos:exactMatch	mesh	C535642	Growth retardation, Alopecia, Pseudoanodontia and Optic atrophy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009488	keratoconus posticus circumscriptus	skos:exactMatch	mesh	C536151	Keratoconus posticus circumscriptus	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009503	pyruvate dehydrogenase E3-binding protein deficiency	skos:exactMatch	mesh	C565447	Pyruvate Dehydrogenase E3-Binding Protein Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009526	fibular aplasia, tibial campomelia, and oligosyndactyly syndrome	skos:exactMatch	mesh	C565436	Fibular Aplasia, Tibial Campomelia, and Oligosyndactyly Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009573	megaepiphyseal dwarfism	skos:exactMatch	mesh	C536140	Megaepiphyseal dwarfism	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009612	methylmalonic aciduria due to methylmalonyl-CoA mutase deficiency	skos:exactMatch	mesh	C565390	Methylmalonic Aciduria due to Methylmalonyl-CoA Mutase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009630	microphthalmia, isolated, with coloboma 4	skos:exactMatch	mesh	C565378	Microphthalmia, Isolated, with Coloboma 4	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009649	moyamoya disease 1	skos:exactMatch	mesh	C536991	Moyamoya disease 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009703	myopathy with abnormal lipid metabolism	skos:exactMatch	mesh	C562935	Myopathy with Abnormal Lipid Metabolism	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009766	oculocerebral hypopigmentation syndrome of Preus	skos:exactMatch	mesh	C537866	Oculocerebral hypopigmentation syndrome type Preus	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009853	Imerslund-Grasbeck syndrome	skos:exactMatch	mesh	C538556	Imerslund-Grasbeck syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0009878	pituitary hormone deficiency, combined, 2	skos:exactMatch	mesh	C563172	Pituitary Hormone Deficiency, Combined, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010056	spinal muscular atrophy, type IV	skos:exactMatch	mesh	C563948	Spinal Muscular Atrophy, Type IV	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010103	teeth, fused	skos:exactMatch	mesh	D005671	Fused Teeth	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010131	thyroid hormone resistance, generalized, autosomal recessive	skos:exactMatch	mesh	C567936	Thyroid Hormone Resistance, Generalized, Autosomal Recessive	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010186	vitamin D-dependent rickets, type 2A	skos:exactMatch	mesh	C562794	Vitamin D-Dependent Rickets, Type 2A	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010201	Winchester syndrome	skos:exactMatch	mesh	C536709	Winchester syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010261	microphthalmia, syndromic 2	skos:exactMatch	mesh	C537465	Microphthalmia, syndromic 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010391	angioma serpiginosum, X-linked	skos:exactMatch	mesh	C536366	Angioma serpiginosum, X-linked	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010535	Bazex-Dupre-Christol syndrome	skos:exactMatch	mesh	C537663	Bazex-Dupre-Christol syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010623	ichthyosis and male hypogonadism	skos:exactMatch	mesh	C537365	Ichthyosis and male hypogonadism	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010644	proteinuria, low molecular weight, with hypercalciuria and nephrocalcinosis	skos:exactMatch	mesh	C545036	Low Molecular Weight Proteinuria with Hypercalciuria and Nephrocalcinosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010693	nystagmus 1, congenital, X-linked	skos:exactMatch	mesh	C537853	Nystagmus 1, congenital, X- linked	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010717	pyruvate dehydrogenase E1-alpha deficiency	skos:exactMatch	mesh	C564071	Pyruvate Dehydrogenase E1 Alpha Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010743	thrombocytopenia 1	skos:exactMatch	mesh	C564052	Thrombocytopenia 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0010760	XH antigen	skos:exactMatch	mesh	C009691	Xh antigen	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011042	Martinez-Frias syndrome	skos:exactMatch	mesh	C563346	Martinez-Frias Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011120	neural tube defects, folate-sensitive	skos:exactMatch	mesh	C536409	Neural tube defect, folate-sensitive	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011544	paragangliomas 3	skos:exactMatch	mesh	C565335	Paragangliomas 3	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011713	melanoma-pancreatic cancer syndrome	skos:exactMatch	mesh	C563985	Melanoma-Pancreatic Cancer Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011826	glucocorticoid deficiency 2	skos:exactMatch	mesh	C564577	Glucocorticoid Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011885	tubulointerstitial nephritis and uveitis syndrome	skos:exactMatch	mesh	C536922	Tubulointerstitial nephritis and uveitis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0011918	anxiety	skos:exactMatch	mesh	D001007	Anxiety	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012164	Meacham syndrome	skos:exactMatch	mesh	C538162	Meacham Winn Culler syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012214	glucocorticoid deficiency 3	skos:exactMatch	mesh	C563776	Glucocorticoid Deficiency 3	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012217	Bruck syndrome 2	skos:exactMatch	mesh	C537407	Bruck syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012252	rhabdoid tumor predisposition syndrome 1	skos:exactMatch	mesh	C563738	Rhabdoid Tumor Predisposition Syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012270	Tukel syndrome	skos:exactMatch	mesh	C536925	Tukel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012287	Stickler syndrome, type I, nonsyndromic ocular	skos:exactMatch	mesh	C563709	Stickler Syndrome, Type I, Nonsyndromic Ocular	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012310	fibrosis of extraocular muscles, congenital, with synergistic divergence	skos:exactMatch	mesh	C566508	Fibrosis of Extraocular Muscles, Congenital, with Synergistic Divergence	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012400	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012408	microphthalmia, isolated, with coloboma 3	skos:exactMatch	mesh	C566447	Microphthalmia, Isolated, with Coloboma 3	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012425	corneal dystrophy, fuchs endothelial, 2	skos:exactMatch	mesh	C535479	Corneal dystrophy, Fuchs' endothelial, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012484	prosopagnosia, hereditary	skos:exactMatch	mesh	C537242	Prosopagnosia, hereditary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0012522	diabetes mellitus, transient neonatal, 3	skos:exactMatch	mesh	C566432	Diabetes Mellitus, Transient Neonatal, 3	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013129	cone dystrophy 4	skos:exactMatch	mesh	C567758	Cone Dystrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013199	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013203	corneal dystrophy, Fuchs endothelial, 3	skos:exactMatch	mesh	C567678	Corneal Dystrophy, Fuchs Endothelial, 3	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013204	corneal dystrophy, Fuchs endothelial, 4	skos:exactMatch	mesh	C567677	Corneal Dystrophy, Fuchs Endothelial, 4	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013205	corneal dystrophy, fuchs endothelial, 5	skos:exactMatch	mesh	C567676	Corneal Dystrophy, Fuchs Endothelial, 5	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013206	corneal dystrophy, Fuchs endothelial, 6	skos:exactMatch	mesh	C567675	Corneal Dystrophy, Fuchs Endothelial, 6	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0013207	corneal dystrophy, fuchs endothelial, 7	skos:exactMatch	mesh	C567674	Corneal Dystrophy, Fuchs Endothelial, 7	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015240	digitotalar dysmorphism	skos:exactMatch	mesh	C565097	Digitotalar Dysmorphism	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015281	atrial standstill	skos:exactMatch	mesh	C563984	Atrial Standstill	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015467	craniosynostosis, Philadelphia type	skos:exactMatch	mesh	C563368	Craniosynostosis, Philadelphia Type	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015993	cone-rod dystrophy	skos:exactMatch	mesh	D000071700	Cone-Rod Dystrophies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0015995	melorheostosis with osteopoikilosis	skos:exactMatch	mesh	C563593	Melorheostosis with Osteopoikilosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016217	mal de Debarquement	skos:exactMatch	mesh	C537840	Mal de debarquement	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016295	neuronal ceroid lipofuscinosis	skos:exactMatch	mesh	D009472	Neuronal Ceroid-Lipofuscinoses	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016301	congenitally corrected transposition of the great arteries	skos:exactMatch	mesh	D000080041	Congenitally Corrected Transposition of the Great Arteries	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016366	maternal phenylketonuria	skos:exactMatch	mesh	D017042	Phenylketonuria, Maternal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016567	locked-in syndrome	skos:exactMatch	mesh	D000080422	Locked-In Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016607	odontohypophosphatasia	skos:exactMatch	mesh	C564146	Odontohypophosphatasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016798	ataxia neuropathy spectrum	skos:exactMatch	mesh	C579922	Ataxia Neuropathy Spectrum	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0016809	spinocerebellar ataxia with epilepsy	skos:exactMatch	mesh	C564395	Spinocerebellar Ataxia with Epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017161	frontotemporal dementia with motor neuron disease	skos:exactMatch	mesh	C566288	Frontotemporal Dementia With Motor Neuron Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017169	multiple endocrine neoplasia	skos:exactMatch	mesh	D009377	Multiple Endocrine Neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017198	osteopetrosis	skos:exactMatch	mesh	D010022	Osteopetrosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017267	self-healing collodion baby	skos:exactMatch	mesh	C565473	Self-Healing Collodion Baby	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017349	myopericytoma	skos:exactMatch	mesh	D000077777	Myopericytoma	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017715	3-hydroxyacyl-CoA dehydrogenase deficiency	skos:exactMatch	mesh	C535310	3-Hydroxyacyl-CoA Dehydrogenase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0017999	fatty acid hydroxylase-associated neurodegeneration	skos:exactMatch	mesh	C580102	Fatty Acid Hydroxylase-Associated Neurodegeneration	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018072	persistent truncus arteriosus	skos:exactMatch	mesh	D014339	Truncus Arteriosus, Persistent	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018082	aorto-ventricular tunnel	skos:exactMatch	mesh	D000082903	Aortico-Ventricular Tunnel	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018135	oculocutaneous albinism type 1	skos:exactMatch	mesh	C537728	Oculocutaneous albinism type 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018154	Madelung deformity	skos:exactMatch	mesh	C562398	Madelung Deformity	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018226	infantile epileptic-dyskinetic encephalopathy	skos:exactMatch	mesh	C567924	Infantile Epileptic-Dyskinetic Encephalopathy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018338	activated PI3K-delta syndrome	skos:exactMatch	mesh	C585640	Activated PI3K-delta Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018363	focal facial dermal dysplasia	skos:exactMatch	mesh	C537068	Focal facial dermal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018668	scedosporiosis	skos:exactMatch	mesh	C000656924	scedosporiosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018781	KID syndrome	skos:exactMatch	mesh	C536168	Keratitis, Ichthyosis, and Deafness (KID) Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018815	aneurysmal bone cyst	skos:exactMatch	mesh	D017824	Bone Cysts, Aneurysmal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018830	Kimura disease	skos:exactMatch	mesh	D000082242	Kimura Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018869	cobblestone lissencephaly	skos:exactMatch	mesh	D054222	Cobblestone Lissencephaly	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018878	branchiootic syndrome	skos:exactMatch	mesh	C537104	Branchiootic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0018949	distal myopathy	skos:exactMatch	mesh	D049310	Distal Myopathies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019107	Rh deficiency syndrome	skos:exactMatch	mesh	C562717	Rh Deficiency Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019155	Leydig cell hypoplasia	skos:exactMatch	mesh	C562567	Leydig Cell Hypoplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019169	pyruvate dehydrogenase deficiency	skos:exactMatch	mesh	D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019353	Stargardt disease	skos:exactMatch	mesh	D000080362	Stargardt Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019669	hypochondrogenesis	skos:exactMatch	mesh	C563007	Hypochondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Terminal Transverse Defects of Arm	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0020110	pulmonary agenesis	skos:exactMatch	mesh	C562992	Lung agenesis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0020756	migraine, familial hemiplegic, 1	skos:exactMatch	mesh	C536890	Hemiplegic migraine, familial type 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0020792	dwarfism with tall vertebrae	skos:exactMatch	mesh	C535725	Dwarfism tall vertebrae	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0020806	sinoatrial block	skos:exactMatch	mesh	D012848	Sinoatrial Block	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021065	pleural neoplasm	skos:exactMatch	mesh	D010997	Pleural Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021092	fallopian tube neoplasm	skos:exactMatch	mesh	D005185	Fallopian Tube Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021106	laminopathy	skos:exactMatch	mesh	D000083083	Laminopathies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021224	iris neoplasm	skos:exactMatch	mesh	D015811	Iris Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021234	spinal cord neoplasm	skos:exactMatch	mesh	D013120	Spinal Cord Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021253	gallbladder neoplasm	skos:exactMatch	mesh	D005706	Gallbladder Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0021662	bile duct neoplasm	skos:exactMatch	mesh	D001650	Bile Duct Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0022140	Charles bonnet syndrome	skos:exactMatch	mesh	D000075562	Charles Bonnet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0022208	crystal arthropathy	skos:exactMatch	mesh	D000070657	Crystal Arthropathies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0023203	Fuchs atrophia gyrata chorioideae et retinae	skos:exactMatch	mesh	C538071	Fuchs atrophia gyrata chorioideae et retinae	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0023305	heavy metal poisoning	skos:exactMatch	mesh	D000075322	Heavy Metal Poisoning	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024264	hypothyroidism, congenital, nongoitrous, 2	skos:exactMatch	mesh	C566852	Hypothyroidism, Congenital, Nongoitrous, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024288	hyperbilirubinemia	skos:exactMatch	mesh	D006932	Hyperbilirubinemia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024332	perennial allergic rhinitis	skos:exactMatch	mesh	D012221	Rhinitis, Allergic, Perennial	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024361	circadian rhythm sleep disorder	skos:exactMatch	mesh	D020178	Sleep Disorders, Circadian Rhythm	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024465	surfactant metabolism dysfunction, pulmonary, 2	skos:exactMatch	mesh	C567048	Surfactant Metabolism Dysfunction, Pulmonary, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024543	brittle cornea syndrome 1	skos:exactMatch	mesh	C536192	Brittle cornea syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024559	aortic aneurysm, familial thoracic 1	skos:exactMatch	mesh	C562834	Aortic Aneurysm, Familial Thoracic 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024647	urolithiasis	skos:exactMatch	mesh	D052878	Urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0024653	skull neoplasm	skos:exactMatch	mesh	D012888	Skull Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0026404	X inactivation, familial skewed, 1	skos:exactMatch	mesh	C564716	X Inactivation, Familial Skewed, 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0026426	X inactivation, familial skewed, 2	skos:exactMatch	mesh	C564572	X Inactivation, Familial Skewed, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0027091	xanthogranulomatous sialadenitis	skos:exactMatch	mesh	C536763	Xanthogranulomatous sialadenitis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0030048	harderoporphyria	skos:exactMatch	mesh	C562816	Harderoporphyria	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0036591	adrenal cortex neoplasm	skos:exactMatch	mesh	D000306	Adrenal Cortex Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0037748	hyperlipoproteinemia	skos:exactMatch	mesh	D006951	Hyperlipoproteinemias	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0041161	endometrial hyperplasia	skos:exactMatch	mesh	D004714	Endometrial Hyperplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0041656	ST-elevation myocardial infarction	skos:exactMatch	mesh	D000072657	ST Elevation Myocardial Infarction	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0041751	multibacillary leprosy	skos:exactMatch	mesh	D056006	Leprosy, Multibacillary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0041752	paucibacillary leprosy	skos:exactMatch	mesh	D056005	Leprosy, Paucibacillary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0044877	paraneoplastic cerebellar degeneration	skos:exactMatch	mesh	D020362	Paraneoplastic Cerebellar Degeneration	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0054868	meconium ileus	skos:exactMatch	mesh	D000074270	Meconium Ileus	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100053	anaphylaxis	skos:exactMatch	mesh	D000707	Anaphylaxis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100075	jaw fracture	skos:exactMatch	mesh	D007572	Jaw Fractures	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100115	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100120	vector-borne disease	skos:exactMatch	mesh	D000079426	Vector Borne Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100128	coinfection	skos:exactMatch	mesh	D060085	Coinfection	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100164	permanent neonatal diabetes mellitus	skos:exactMatch	mesh	C563425	Diabetes Mellitus, Permanent Neonatal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100185	immune reconstitution inflammatory syndrome	skos:exactMatch	mesh	D054019	Immune Reconstitution Inflammatory Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100192	liver failure	skos:exactMatch	mesh	D017093	Liver Failure	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100338	urinary tract infection	skos:exactMatch	mesh	D014552	Urinary Tract Infections	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100345	lactose intolerance	skos:exactMatch	mesh	D007787	Lactose Intolerance	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100350	neuronopathy, distal hereditary motor, type 5	skos:exactMatch	mesh	C563443	Neuronopathy, Distal Hereditary Motor, Type V	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100457	achalasia, familial esophageal	skos:exactMatch	mesh	C536011	Achalasia, familial esophageal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0100482	extensively drug-resistant tuberculosis	skos:exactMatch	mesh	D054908	Extensively Drug-Resistant Tuberculosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0400005	refeeding syndrome	skos:exactMatch	mesh	D055677	Refeeding Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0600008	cytokine release syndrome	skos:exactMatch	mesh	D000080424	Cytokine Release Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0700064	aneuploidy	skos:exactMatch	mesh	D000782	Aneuploidy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0700065	trisomy	skos:exactMatch	mesh	D014314	Trisomy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	0700086	uniparental disomy	skos:exactMatch	mesh	D024182	Uniparental Disomy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	8000018	benign paroxysmal positional vertigo	skos:exactMatch	mesh	D065635	Benign Paroxysmal Positional Vertigo	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	8000019	vertigo, benign recurrent, 1	skos:exactMatch	mesh	C567620	Vertigo, Benign Recurrent, 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000158	developmental dysplasia of the hip	skos:exactMatch	mesh	D000082602	Developmental Dysplasia of the Hip	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000239	adiaspiromycosis	skos:exactMatch	mesh	C000656784	adiaspiromycosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000242	tinea barbae	skos:exactMatch	mesh	C000656825	tinea barbae	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000455	cone dystrophy	skos:exactMatch	mesh	D000077765	Cone Dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000598	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000716	agraphia	skos:exactMatch	mesh	D000381	Agraphia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0000819	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001020	amblyopia	skos:exactMatch	mesh	D000550	Amblyopia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001045	intestinal atresia	skos:exactMatch	mesh	D007409	Intestinal Atresia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001134	essential hypertension	skos:exactMatch	mesh	D000075222	Essential Hypertension	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001149	microcephaly	skos:exactMatch	mesh	D008831	Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001247	social phobia	skos:exactMatch	mesh	D000072861	Phobia, Social	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001357	hypochromic anemia	skos:exactMatch	mesh	D000747	Anemia, Hypochromic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic Neuropathy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0002012	methylmalonic acidemia	skos:exactMatch	mesh	C537358	Methylmalonic acidemia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0002648	mammary Paget disease	skos:exactMatch	mesh	D010144	Paget's Disease, Mammary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0005607	chronic bronchitis	skos:exactMatch	mesh	D029481	Bronchitis, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0006033	diffuse intrinsic pontine glioma	skos:exactMatch	mesh	D000080443	Diffuse Intrinsic Pontine Glioma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0006094	Askin tumor	skos:exactMatch	mesh	C563168	Askin Tumor	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007082	alopecia areata 1	skos:exactMatch	mesh	C566303	Alopecia Areata 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007088	Alzheimer disease type 1	skos:exactMatch	mesh	C536594	Alzheimer disease type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007110	Diamond-Blackfan anemia 1	skos:exactMatch	mesh	C567302	Diamond-Blackfan Anemia 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007329	cirrhosis, familial	skos:exactMatch	mesh	C566123	Cirrhosis, Familial	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007390	coumarin resistance	skos:exactMatch	mesh	C563039	Coumarin Resistance	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007440	major affective disorder 1	skos:exactMatch	mesh	C565111	Major Affective Disorder 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007459	dilution, pigmentary	skos:exactMatch	mesh	C566872	Dilution, Pigmentary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007547	epidermoid cysts	skos:exactMatch	mesh	D004814	Epidermal Cyst	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007578	esterase B	skos:exactMatch	mesh	C049262	esterase B	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007817	IgE responsiveness, atopic	skos:exactMatch	mesh	C564133	Ige Responsiveness, Atopic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007909	familial multiple lipomatosis	skos:exactMatch	mesh	D000071070	Familial Multiple Lipomatosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0007942	Mammastatin	skos:exactMatch	mesh	C060120	mammastatin	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008062	narcolepsy 1	skos:exactMatch	mesh	C563534	Narcolepsy 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008163	otofaciocervical syndrome	skos:exactMatch	mesh	C563481	Otofaciocervical Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008197	parietal foramina 1	skos:exactMatch	mesh	C566827	Parietal Foramina 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008273	actinic prurigo	skos:exactMatch	mesh	C566780	Actinic Prurigo	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008328	glaucoma 1, open angle, P	skos:exactMatch	mesh	C566748	Glaucoma 1, Open Angle, P	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008426	Shprintzen-Goldberg syndrome	skos:exactMatch	mesh	C537328	Shprintzen Golberg craniosynostosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008527	tarsal coalition	skos:exactMatch	mesh	D000070604	Tarsal Coalition	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008597	trichorhinophalangeal syndrome, type III	skos:exactMatch	mesh	C566033	Trichorhinophalangeal Syndrome, Type III	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008612	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008734	adrenocortical carcinoma, hereditary	skos:exactMatch	mesh	C565972	Adrenocortical Carcinoma, Hereditary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0008738	aganglionosis, total intestinal	skos:exactMatch	mesh	C538058	Aganglionosis, total intestinal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009003	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009130	Dyggve-Melchior-Clausen disease	skos:exactMatch	mesh	C535726	Dyggve-Melchior-Clausen syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009175	eosinophilic fasciitis	skos:exactMatch	mesh	C562487	Eosinophilic Fasciitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009202	Thakker-Donnai syndrome	skos:exactMatch	mesh	C536503	Thakker Donnai syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009220	visceral steatosis, congenital	skos:exactMatch	mesh	C536351	Visceral Steatosis, Congenital	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009263	gapo syndrome	skos:exactMatch	mesh	C535642	Growth retardation, Alopecia, Pseudoanodontia and Optic atrophy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009488	keratoconus posticus circumscriptus	skos:exactMatch	mesh	C536151	Keratoconus posticus circumscriptus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009503	pyruvate dehydrogenase E3-binding protein deficiency	skos:exactMatch	mesh	C565447	Pyruvate Dehydrogenase E3-Binding Protein Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009526	fibular aplasia, tibial campomelia, and oligosyndactyly syndrome	skos:exactMatch	mesh	C565436	Fibular Aplasia, Tibial Campomelia, and Oligosyndactyly Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009573	megaepiphyseal dwarfism	skos:exactMatch	mesh	C536140	Megaepiphyseal dwarfism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009612	methylmalonic aciduria due to methylmalonyl-CoA mutase deficiency	skos:exactMatch	mesh	C565390	Methylmalonic Aciduria due to Methylmalonyl-CoA Mutase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009630	microphthalmia, isolated, with coloboma 4	skos:exactMatch	mesh	C565378	Microphthalmia, Isolated, with Coloboma 4	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009649	moyamoya disease 1	skos:exactMatch	mesh	C536991	Moyamoya disease 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009703	myopathy with abnormal lipid metabolism	skos:exactMatch	mesh	C562935	Myopathy with Abnormal Lipid Metabolism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009766	oculocerebral hypopigmentation syndrome of Preus	skos:exactMatch	mesh	C537866	Oculocerebral hypopigmentation syndrome type Preus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009853	Imerslund-Grasbeck syndrome	skos:exactMatch	mesh	C538556	Imerslund-Grasbeck syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0009878	pituitary hormone deficiency, combined, 2	skos:exactMatch	mesh	C563172	Pituitary Hormone Deficiency, Combined, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010056	spinal muscular atrophy, type IV	skos:exactMatch	mesh	C563948	Spinal Muscular Atrophy, Type IV	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010103	teeth, fused	skos:exactMatch	mesh	D005671	Fused Teeth	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010131	thyroid hormone resistance, generalized, autosomal recessive	skos:exactMatch	mesh	C567936	Thyroid Hormone Resistance, Generalized, Autosomal Recessive	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010186	vitamin D-dependent rickets, type 2A	skos:exactMatch	mesh	C562794	Vitamin D-Dependent Rickets, Type 2A	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010201	Winchester syndrome	skos:exactMatch	mesh	C536709	Winchester syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010261	microphthalmia, syndromic 2	skos:exactMatch	mesh	C537465	Microphthalmia, syndromic 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010391	angioma serpiginosum, X-linked	skos:exactMatch	mesh	C536366	Angioma serpiginosum, X-linked	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010535	Bazex-Dupre-Christol syndrome	skos:exactMatch	mesh	C537663	Bazex-Dupre-Christol syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010623	ichthyosis and male hypogonadism	skos:exactMatch	mesh	C537365	Ichthyosis and male hypogonadism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010644	proteinuria, low molecular weight, with hypercalciuria and nephrocalcinosis	skos:exactMatch	mesh	C545036	Low Molecular Weight Proteinuria with Hypercalciuria and Nephrocalcinosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010693	nystagmus 1, congenital, X-linked	skos:exactMatch	mesh	C537853	Nystagmus 1, congenital, X- linked	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010717	pyruvate dehydrogenase E1-alpha deficiency	skos:exactMatch	mesh	C564071	Pyruvate Dehydrogenase E1 Alpha Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010743	thrombocytopenia 1	skos:exactMatch	mesh	C564052	Thrombocytopenia 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0010760	XH antigen	skos:exactMatch	mesh	C009691	Xh antigen	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011042	Martinez-Frias syndrome	skos:exactMatch	mesh	C563346	Martinez-Frias Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011120	neural tube defects, folate-sensitive	skos:exactMatch	mesh	C536409	Neural tube defect, folate-sensitive	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011544	paragangliomas 3	skos:exactMatch	mesh	C565335	Paragangliomas 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011713	melanoma-pancreatic cancer syndrome	skos:exactMatch	mesh	C563985	Melanoma-Pancreatic Cancer Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011826	glucocorticoid deficiency 2	skos:exactMatch	mesh	C564577	Glucocorticoid Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011885	tubulointerstitial nephritis and uveitis syndrome	skos:exactMatch	mesh	C536922	Tubulointerstitial nephritis and uveitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0011918	anxiety	skos:exactMatch	mesh	D001007	Anxiety	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012164	Meacham syndrome	skos:exactMatch	mesh	C538162	Meacham Winn Culler syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012214	glucocorticoid deficiency 3	skos:exactMatch	mesh	C563776	Glucocorticoid Deficiency 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012217	Bruck syndrome 2	skos:exactMatch	mesh	C537407	Bruck syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012252	rhabdoid tumor predisposition syndrome 1	skos:exactMatch	mesh	C563738	Rhabdoid Tumor Predisposition Syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012270	Tukel syndrome	skos:exactMatch	mesh	C536925	Tukel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012287	Stickler syndrome, type I, nonsyndromic ocular	skos:exactMatch	mesh	C563709	Stickler Syndrome, Type I, Nonsyndromic Ocular	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012310	fibrosis of extraocular muscles, congenital, with synergistic divergence	skos:exactMatch	mesh	C566508	Fibrosis of Extraocular Muscles, Congenital, with Synergistic Divergence	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012400	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012408	microphthalmia, isolated, with coloboma 3	skos:exactMatch	mesh	C566447	Microphthalmia, Isolated, with Coloboma 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012425	corneal dystrophy, fuchs endothelial, 2	skos:exactMatch	mesh	C535479	Corneal dystrophy, Fuchs' endothelial, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012484	prosopagnosia, hereditary	skos:exactMatch	mesh	C537242	Prosopagnosia, hereditary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0012522	diabetes mellitus, transient neonatal, 3	skos:exactMatch	mesh	C566432	Diabetes Mellitus, Transient Neonatal, 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013129	cone dystrophy 4	skos:exactMatch	mesh	C567758	Cone Dystrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013199	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013203	corneal dystrophy, Fuchs endothelial, 3	skos:exactMatch	mesh	C567678	Corneal Dystrophy, Fuchs Endothelial, 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013204	corneal dystrophy, Fuchs endothelial, 4	skos:exactMatch	mesh	C567677	Corneal Dystrophy, Fuchs Endothelial, 4	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013205	corneal dystrophy, fuchs endothelial, 5	skos:exactMatch	mesh	C567676	Corneal Dystrophy, Fuchs Endothelial, 5	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013206	corneal dystrophy, Fuchs endothelial, 6	skos:exactMatch	mesh	C567675	Corneal Dystrophy, Fuchs Endothelial, 6	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0013207	corneal dystrophy, fuchs endothelial, 7	skos:exactMatch	mesh	C567674	Corneal Dystrophy, Fuchs Endothelial, 7	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015240	digitotalar dysmorphism	skos:exactMatch	mesh	C565097	Digitotalar Dysmorphism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015281	atrial standstill	skos:exactMatch	mesh	C563984	Atrial Standstill	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015467	craniosynostosis, Philadelphia type	skos:exactMatch	mesh	C563368	Craniosynostosis, Philadelphia Type	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015993	cone-rod dystrophy	skos:exactMatch	mesh	D000071700	Cone-Rod Dystrophies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0015995	melorheostosis with osteopoikilosis	skos:exactMatch	mesh	C563593	Melorheostosis with Osteopoikilosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016217	mal de Debarquement	skos:exactMatch	mesh	C537840	Mal de debarquement	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016295	neuronal ceroid lipofuscinosis	skos:exactMatch	mesh	D009472	Neuronal Ceroid-Lipofuscinoses	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016301	congenitally corrected transposition of the great arteries	skos:exactMatch	mesh	D000080041	Congenitally Corrected Transposition of the Great Arteries	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016366	maternal phenylketonuria	skos:exactMatch	mesh	D017042	Phenylketonuria, Maternal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016567	locked-in syndrome	skos:exactMatch	mesh	D000080422	Locked-In Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016607	odontohypophosphatasia	skos:exactMatch	mesh	C564146	Odontohypophosphatasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016798	ataxia neuropathy spectrum	skos:exactMatch	mesh	C579922	Ataxia Neuropathy Spectrum	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0016809	spinocerebellar ataxia with epilepsy	skos:exactMatch	mesh	C564395	Spinocerebellar Ataxia with Epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017161	frontotemporal dementia with motor neuron disease	skos:exactMatch	mesh	C566288	Frontotemporal Dementia With Motor Neuron Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017169	multiple endocrine neoplasia	skos:exactMatch	mesh	D009377	Multiple Endocrine Neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017198	osteopetrosis	skos:exactMatch	mesh	D010022	Osteopetrosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017267	self-healing collodion baby	skos:exactMatch	mesh	C565473	Self-Healing Collodion Baby	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017349	myopericytoma	skos:exactMatch	mesh	D000077777	Myopericytoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017715	3-hydroxyacyl-CoA dehydrogenase deficiency	skos:exactMatch	mesh	C535310	3-Hydroxyacyl-CoA Dehydrogenase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0017999	fatty acid hydroxylase-associated neurodegeneration	skos:exactMatch	mesh	C580102	Fatty Acid Hydroxylase-Associated Neurodegeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018072	persistent truncus arteriosus	skos:exactMatch	mesh	D014339	Truncus Arteriosus, Persistent	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018082	aorto-ventricular tunnel	skos:exactMatch	mesh	D000082903	Aortico-Ventricular Tunnel	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018135	oculocutaneous albinism type 1	skos:exactMatch	mesh	C537728	Oculocutaneous albinism type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018154	Madelung deformity	skos:exactMatch	mesh	C562398	Madelung Deformity	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018226	infantile epileptic-dyskinetic encephalopathy	skos:exactMatch	mesh	C567924	Infantile Epileptic-Dyskinetic Encephalopathy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018338	activated PI3K-delta syndrome	skos:exactMatch	mesh	C585640	Activated PI3K-delta Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018363	focal facial dermal dysplasia	skos:exactMatch	mesh	C537068	Focal facial dermal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018668	scedosporiosis	skos:exactMatch	mesh	C000656924	scedosporiosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018781	KID syndrome	skos:exactMatch	mesh	C536168	Keratitis, Ichthyosis, and Deafness (KID) Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018815	aneurysmal bone cyst	skos:exactMatch	mesh	D017824	Bone Cysts, Aneurysmal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018830	Kimura disease	skos:exactMatch	mesh	D000082242	Kimura Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018869	cobblestone lissencephaly	skos:exactMatch	mesh	D054222	Cobblestone Lissencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018878	branchiootic syndrome	skos:exactMatch	mesh	C537104	Branchiootic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0018949	distal myopathy	skos:exactMatch	mesh	D049310	Distal Myopathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019107	Rh deficiency syndrome	skos:exactMatch	mesh	C562717	Rh Deficiency Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019155	Leydig cell hypoplasia	skos:exactMatch	mesh	C562567	Leydig Cell Hypoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019169	pyruvate dehydrogenase deficiency	skos:exactMatch	mesh	D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019353	Stargardt disease	skos:exactMatch	mesh	D000080362	Stargardt Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019669	hypochondrogenesis	skos:exactMatch	mesh	C563007	Hypochondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Terminal Transverse Defects of Arm	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020110	pulmonary agenesis	skos:exactMatch	mesh	C562992	Lung agenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020756	migraine, familial hemiplegic, 1	skos:exactMatch	mesh	C536890	Hemiplegic migraine, familial type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020792	dwarfism with tall vertebrae	skos:exactMatch	mesh	C535725	Dwarfism tall vertebrae	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0020806	sinoatrial block	skos:exactMatch	mesh	D012848	Sinoatrial Block	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021065	pleural neoplasm	skos:exactMatch	mesh	D010997	Pleural Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021092	fallopian tube neoplasm	skos:exactMatch	mesh	D005185	Fallopian Tube Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021106	laminopathy	skos:exactMatch	mesh	D000083083	Laminopathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021224	iris neoplasm	skos:exactMatch	mesh	D015811	Iris Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021234	spinal cord neoplasm	skos:exactMatch	mesh	D013120	Spinal Cord Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021253	gallbladder neoplasm	skos:exactMatch	mesh	D005706	Gallbladder Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0021662	bile duct neoplasm	skos:exactMatch	mesh	D001650	Bile Duct Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0022140	Charles bonnet syndrome	skos:exactMatch	mesh	D000075562	Charles Bonnet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0022208	crystal arthropathy	skos:exactMatch	mesh	D000070657	Crystal Arthropathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0023203	Fuchs atrophia gyrata chorioideae et retinae	skos:exactMatch	mesh	C538071	Fuchs atrophia gyrata chorioideae et retinae	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0023305	heavy metal poisoning	skos:exactMatch	mesh	D000075322	Heavy Metal Poisoning	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024264	hypothyroidism, congenital, nongoitrous, 2	skos:exactMatch	mesh	C566852	Hypothyroidism, Congenital, Nongoitrous, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024288	hyperbilirubinemia	skos:exactMatch	mesh	D006932	Hyperbilirubinemia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024332	perennial allergic rhinitis	skos:exactMatch	mesh	D012221	Rhinitis, Allergic, Perennial	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024361	circadian rhythm sleep disorder	skos:exactMatch	mesh	D020178	Sleep Disorders, Circadian Rhythm	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024465	surfactant metabolism dysfunction, pulmonary, 2	skos:exactMatch	mesh	C567048	Surfactant Metabolism Dysfunction, Pulmonary, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024543	brittle cornea syndrome 1	skos:exactMatch	mesh	C536192	Brittle cornea syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024559	aortic aneurysm, familial thoracic 1	skos:exactMatch	mesh	C562834	Aortic Aneurysm, Familial Thoracic 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024647	urolithiasis	skos:exactMatch	mesh	D052878	Urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0024653	skull neoplasm	skos:exactMatch	mesh	D012888	Skull Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0026404	X inactivation, familial skewed, 1	skos:exactMatch	mesh	C564716	X Inactivation, Familial Skewed, 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0026426	X inactivation, familial skewed, 2	skos:exactMatch	mesh	C564572	X Inactivation, Familial Skewed, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0027091	xanthogranulomatous sialadenitis	skos:exactMatch	mesh	C536763	Xanthogranulomatous sialadenitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0030048	harderoporphyria	skos:exactMatch	mesh	C562816	Harderoporphyria	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0036591	adrenal cortex neoplasm	skos:exactMatch	mesh	D000306	Adrenal Cortex Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0037748	hyperlipoproteinemia	skos:exactMatch	mesh	D006951	Hyperlipoproteinemias	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041161	endometrial hyperplasia	skos:exactMatch	mesh	D004714	Endometrial Hyperplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041656	ST-elevation myocardial infarction	skos:exactMatch	mesh	D000072657	ST Elevation Myocardial Infarction	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041751	multibacillary leprosy	skos:exactMatch	mesh	D056006	Leprosy, Multibacillary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0041752	paucibacillary leprosy	skos:exactMatch	mesh	D056005	Leprosy, Paucibacillary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0044877	paraneoplastic cerebellar degeneration	skos:exactMatch	mesh	D020362	Paraneoplastic Cerebellar Degeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0054868	meconium ileus	skos:exactMatch	mesh	D000074270	Meconium Ileus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100053	anaphylaxis	skos:exactMatch	mesh	D000707	Anaphylaxis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100075	jaw fracture	skos:exactMatch	mesh	D007572	Jaw Fractures	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100115	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100120	vector-borne disease	skos:exactMatch	mesh	D000079426	Vector Borne Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100128	coinfection	skos:exactMatch	mesh	D060085	Coinfection	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100164	permanent neonatal diabetes mellitus	skos:exactMatch	mesh	C563425	Diabetes Mellitus, Permanent Neonatal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100185	immune reconstitution inflammatory syndrome	skos:exactMatch	mesh	D054019	Immune Reconstitution Inflammatory Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100192	liver failure	skos:exactMatch	mesh	D017093	Liver Failure	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100338	urinary tract infection	skos:exactMatch	mesh	D014552	Urinary Tract Infections	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100345	lactose intolerance	skos:exactMatch	mesh	D007787	Lactose Intolerance	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100350	neuronopathy, distal hereditary motor, type 5	skos:exactMatch	mesh	C563443	Neuronopathy, Distal Hereditary Motor, Type V	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100457	achalasia, familial esophageal	skos:exactMatch	mesh	C536011	Achalasia, familial esophageal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0100482	extensively drug-resistant tuberculosis	skos:exactMatch	mesh	D054908	Extensively Drug-Resistant Tuberculosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0400005	refeeding syndrome	skos:exactMatch	mesh	D055677	Refeeding Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0600008	cytokine release syndrome	skos:exactMatch	mesh	D000080424	Cytokine Release Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0700064	aneuploidy	skos:exactMatch	mesh	D000782	Aneuploidy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0700065	trisomy	skos:exactMatch	mesh	D014314	Trisomy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:0700086	uniparental disomy	skos:exactMatch	mesh	D024182	Uniparental Disomy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:8000018	benign paroxysmal positional vertigo	skos:exactMatch	mesh	D065635	Benign Paroxysmal Positional Vertigo	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	MONDO:8000019	vertigo, benign recurrent, 1	skos:exactMatch	mesh	C567620	Vertigo, Benign Recurrent, 1	manually_reviewed	orcid:0000-0001-9439-5346
 ncit	C1707	Voriconazole	skos:exactMatch	chebi	CHEBI:10023	voriconazole	manual	orcid:0000-0003-4423-4370
 ncit	C2160	Proteasome Inhibitor	skos:exactMatch	chebi	CHEBI:52726	proteasome inhibitor	manual	orcid:0000-0003-4423-4370
 ncit	C65538	Esomeprazole	skos:exactMatch	chebi	CHEBI:50275	esomeprazole	manual	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -6447,106 +6447,106 @@ mesh	D066270	Social Capital	skos:exactMatch	ncit	C93209	Social Capital	manually_
 mesh	D066271	External Capsule	skos:exactMatch	ncit	C32550	External Capsule	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066292	Lipid Droplets	skos:exactMatch	go	GO:0005811	lipid droplet	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D066293	Renshaw Cells	skos:exactMatch	ncit	C33463	Renshaw Cell	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000158	developmental dysplasia of the hip	skos:exactMatch	mesh	D000082602	Developmental Dysplasia of the Hip	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000239	adiaspiromycosis	skos:exactMatch	mesh	C000656784	adiaspiromycosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000242	tinea barbae	skos:exactMatch	mesh	C000656825	tinea barbae	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000455	cone dystrophy	skos:exactMatch	mesh	D000077765	Cone Dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000598	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000716	agraphia	skos:exactMatch	mesh	D000381	Agraphia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0000819	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001020	amblyopia	skos:exactMatch	mesh	D000550	Amblyopia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001045	intestinal atresia	skos:exactMatch	mesh	D007409	Intestinal Atresia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001134	essential hypertension	skos:exactMatch	mesh	D000075222	Essential Hypertension	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001149	microcephaly	skos:exactMatch	mesh	D008831	Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001247	social phobia	skos:exactMatch	mesh	D000072861	Phobia, Social	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001357	hypochromic anemia	skos:exactMatch	mesh	D000747	Anemia, Hypochromic	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic Neuropathy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016217	mal de Debarquement	skos:exactMatch	mesh	C537840	Mal de debarquement	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016295	neuronal ceroid lipofuscinosis	skos:exactMatch	mesh	D009472	Neuronal Ceroid-Lipofuscinoses	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016301	congenitally corrected transposition of the great arteries	skos:exactMatch	mesh	D000080041	Congenitally Corrected Transposition of the Great Arteries	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016567	locked-in syndrome	skos:exactMatch	mesh	D000080422	Locked-In Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016607	odontohypophosphatasia	skos:exactMatch	mesh	C564146	Odontohypophosphatasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016798	ataxia neuropathy spectrum	skos:exactMatch	mesh	C579922	Ataxia Neuropathy Spectrum	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0016809	spinocerebellar ataxia with epilepsy	skos:exactMatch	mesh	C564395	Spinocerebellar Ataxia with Epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0017161	frontotemporal dementia with motor neuron disease	skos:exactMatch	mesh	C566288	Frontotemporal Dementia With Motor Neuron Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0017169	multiple endocrine neoplasia	skos:exactMatch	mesh	D009377	Multiple Endocrine Neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0017198	osteopetrosis	skos:exactMatch	mesh	D010022	Osteopetrosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0017267	self-healing collodion baby	skos:exactMatch	mesh	C565473	Self-Healing Collodion Baby	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0017349	myopericytoma	skos:exactMatch	mesh	D000077777	Myopericytoma	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0017999	fatty acid hydroxylase-associated neurodegeneration	skos:exactMatch	mesh	C580102	Fatty Acid Hydroxylase-Associated Neurodegeneration	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018082	aorto-ventricular tunnel	skos:exactMatch	mesh	D000082903	Aortico-Ventricular Tunnel	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018135	oculocutaneous albinism type 1	skos:exactMatch	mesh	C537728	Oculocutaneous albinism type 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018154	Madelung deformity	skos:exactMatch	mesh	C562398	Madelung Deformity	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018338	activated PI3K-delta syndrome	skos:exactMatch	mesh	C585640	Activated PI3K-delta Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018363	focal facial dermal dysplasia	skos:exactMatch	mesh	C537068	Focal facial dermal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018668	scedosporiosis	skos:exactMatch	mesh	C000656924	scedosporiosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018815	aneurysmal bone cyst	skos:exactMatch	mesh	D017824	Bone Cysts, Aneurysmal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018830	Kimura disease	skos:exactMatch	mesh	D000082242	Kimura Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018869	cobblestone lissencephaly	skos:exactMatch	mesh	D054222	Cobblestone Lissencephaly	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018878	branchiootic syndrome	skos:exactMatch	mesh	C537104	Branchiootic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0018949	distal myopathy	skos:exactMatch	mesh	D049310	Distal Myopathies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019107	Rh deficiency syndrome	skos:exactMatch	mesh	C562717	Rh Deficiency Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019155	Leydig cell hypoplasia	skos:exactMatch	mesh	C562567	Leydig Cell Hypoplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019169	pyruvate dehydrogenase deficiency	skos:exactMatch	mesh	D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019353	Stargardt disease	skos:exactMatch	mesh	D000080362	Stargardt Disease	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019669	hypochondrogenesis	skos:exactMatch	mesh	C563007	Hypochondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Terminal Transverse Defects of Arm	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0020806	sinoatrial block	skos:exactMatch	mesh	D012848	Sinoatrial Block	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021065	pleural neoplasm	skos:exactMatch	mesh	D010997	Pleural Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021092	fallopian tube neoplasm	skos:exactMatch	mesh	D005185	Fallopian Tube Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021106	laminopathy	skos:exactMatch	mesh	D000083083	Laminopathies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021224	iris neoplasm	skos:exactMatch	mesh	D015811	Iris Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021234	spinal cord neoplasm	skos:exactMatch	mesh	D013120	Spinal Cord Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021253	gallbladder neoplasm	skos:exactMatch	mesh	D005706	Gallbladder Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0021662	bile duct neoplasm	skos:exactMatch	mesh	D001650	Bile Duct Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0022140	Charles bonnet syndrome	skos:exactMatch	mesh	D000075562	Charles Bonnet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0022208	crystal arthropathy	skos:exactMatch	mesh	D000070657	Crystal Arthropathies	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0023305	heavy metal poisoning	skos:exactMatch	mesh	D000075322	Heavy Metal Poisoning	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024264	hypothyroidism, congenital, nongoitrous, 2	skos:exactMatch	mesh	C566852	Hypothyroidism, Congenital, Nongoitrous, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024288	hyperbilirubinemia	skos:exactMatch	mesh	D006932	Hyperbilirubinemia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024332	perennial allergic rhinitis	skos:exactMatch	mesh	D012221	Rhinitis, Allergic, Perennial	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024361	circadian rhythm sleep disorder	skos:exactMatch	mesh	D020178	Sleep Disorders, Circadian Rhythm	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024465	surfactant metabolism dysfunction, pulmonary, 2	skos:exactMatch	mesh	C567048	Surfactant Metabolism Dysfunction, Pulmonary, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024559	aortic aneurysm, familial thoracic 1	skos:exactMatch	mesh	C562834	Aortic Aneurysm, Familial Thoracic 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024647	urolithiasis	skos:exactMatch	mesh	D052878	Urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0024653	skull neoplasm	skos:exactMatch	mesh	D012888	Skull Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0026404	X inactivation, familial skewed, 1	skos:exactMatch	mesh	C564716	X Inactivation, Familial Skewed, 1	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0026426	X inactivation, familial skewed, 2	skos:exactMatch	mesh	C564572	X Inactivation, Familial Skewed, 2	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0027091	xanthogranulomatous sialadenitis	skos:exactMatch	mesh	C536763	Xanthogranulomatous sialadenitis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0030048	harderoporphyria	skos:exactMatch	mesh	C562816	Harderoporphyria	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0036591	adrenal cortex neoplasm	skos:exactMatch	mesh	D000306	Adrenal Cortex Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0037748	hyperlipoproteinemia	skos:exactMatch	mesh	D006951	Hyperlipoproteinemias	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0041161	endometrial hyperplasia	skos:exactMatch	mesh	D004714	Endometrial Hyperplasia	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0041656	ST-elevation myocardial infarction	skos:exactMatch	mesh	D000072657	ST Elevation Myocardial Infarction	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0041751	multibacillary leprosy	skos:exactMatch	mesh	D056006	Leprosy, Multibacillary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0041752	paucibacillary leprosy	skos:exactMatch	mesh	D056005	Leprosy, Paucibacillary	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0044877	paraneoplastic cerebellar degeneration	skos:exactMatch	mesh	D020362	Paraneoplastic Cerebellar Degeneration	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0054868	meconium ileus	skos:exactMatch	mesh	D000074270	Meconium Ileus	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100053	anaphylaxis	skos:exactMatch	mesh	D000707	Anaphylaxis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100075	jaw fracture	skos:exactMatch	mesh	D007572	Jaw Fractures	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100115	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100120	vector-borne disease	skos:exactMatch	mesh	D000079426	Vector Borne Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100128	coinfection	skos:exactMatch	mesh	D060085	Coinfection	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100164	permanent neonatal diabetes mellitus	skos:exactMatch	mesh	C563425	Diabetes Mellitus, Permanent Neonatal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100192	liver failure	skos:exactMatch	mesh	D017093	Liver Failure	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100338	urinary tract infection	skos:exactMatch	mesh	D014552	Urinary Tract Infections	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100345	lactose intolerance	skos:exactMatch	mesh	D007787	Lactose Intolerance	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100350	neuronopathy, distal hereditary motor, type 5	skos:exactMatch	mesh	C563443	Neuronopathy, Distal Hereditary Motor, Type V	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100457	achalasia, familial esophageal	skos:exactMatch	mesh	C536011	Achalasia, familial esophageal	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0100482	extensively drug-resistant tuberculosis	skos:exactMatch	mesh	D054908	Extensively Drug-Resistant Tuberculosis	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0400005	refeeding syndrome	skos:exactMatch	mesh	D055677	Refeeding Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0600008	cytokine release syndrome	skos:exactMatch	mesh	D000080424	Cytokine Release Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0700064	aneuploidy	skos:exactMatch	mesh	D000782	Aneuploidy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0700065	trisomy	skos:exactMatch	mesh	D014314	Trisomy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:0700086	uniparental disomy	skos:exactMatch	mesh	D024182	Uniparental Disomy	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:8000018	benign paroxysmal positional vertigo	skos:exactMatch	mesh	D065635	Benign Paroxysmal Positional Vertigo	manually_reviewed	orcid:0000-0001-9439-5346
-mondo	MONDO:8000019	vertigo, benign recurrent, 1	skos:exactMatch	mesh	C567620	Vertigo, Benign Recurrent, 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000158	developmental dysplasia of the hip	skos:exactMatch	mesh	D000082602	Developmental Dysplasia of the Hip	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000239	adiaspiromycosis	skos:exactMatch	mesh	C000656784	adiaspiromycosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000242	tinea barbae	skos:exactMatch	mesh	C000656825	tinea barbae	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000455	cone dystrophy	skos:exactMatch	mesh	D000077765	Cone Dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000598	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000716	agraphia	skos:exactMatch	mesh	D000381	Agraphia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0000819	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001020	amblyopia	skos:exactMatch	mesh	D000550	Amblyopia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001045	intestinal atresia	skos:exactMatch	mesh	D007409	Intestinal Atresia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001134	essential hypertension	skos:exactMatch	mesh	D000075222	Essential Hypertension	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001149	microcephaly	skos:exactMatch	mesh	D008831	Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001247	social phobia	skos:exactMatch	mesh	D000072861	Phobia, Social	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001357	hypochromic anemia	skos:exactMatch	mesh	D000747	Anemia, Hypochromic	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0001688	toxic optic neuropathy	skos:exactMatch	mesh	D000081028	Toxic Optic Neuropathy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016217	mal de Debarquement	skos:exactMatch	mesh	C537840	Mal de debarquement	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016295	neuronal ceroid lipofuscinosis	skos:exactMatch	mesh	D009472	Neuronal Ceroid-Lipofuscinoses	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016301	congenitally corrected transposition of the great arteries	skos:exactMatch	mesh	D000080041	Congenitally Corrected Transposition of the Great Arteries	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016567	locked-in syndrome	skos:exactMatch	mesh	D000080422	Locked-In Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016607	odontohypophosphatasia	skos:exactMatch	mesh	C564146	Odontohypophosphatasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016798	ataxia neuropathy spectrum	skos:exactMatch	mesh	C579922	Ataxia Neuropathy Spectrum	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016809	spinocerebellar ataxia with epilepsy	skos:exactMatch	mesh	C564395	Spinocerebellar Ataxia with Epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017161	frontotemporal dementia with motor neuron disease	skos:exactMatch	mesh	C566288	Frontotemporal Dementia With Motor Neuron Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017169	multiple endocrine neoplasia	skos:exactMatch	mesh	D009377	Multiple Endocrine Neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017198	osteopetrosis	skos:exactMatch	mesh	D010022	Osteopetrosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017267	self-healing collodion baby	skos:exactMatch	mesh	C565473	Self-Healing Collodion Baby	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017349	myopericytoma	skos:exactMatch	mesh	D000077777	Myopericytoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017999	fatty acid hydroxylase-associated neurodegeneration	skos:exactMatch	mesh	C580102	Fatty Acid Hydroxylase-Associated Neurodegeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018082	aorto-ventricular tunnel	skos:exactMatch	mesh	D000082903	Aortico-Ventricular Tunnel	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018135	oculocutaneous albinism type 1	skos:exactMatch	mesh	C537728	Oculocutaneous albinism type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018154	Madelung deformity	skos:exactMatch	mesh	C562398	Madelung Deformity	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018338	activated PI3K-delta syndrome	skos:exactMatch	mesh	C585640	Activated PI3K-delta Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018363	focal facial dermal dysplasia	skos:exactMatch	mesh	C537068	Focal facial dermal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018668	scedosporiosis	skos:exactMatch	mesh	C000656924	scedosporiosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018815	aneurysmal bone cyst	skos:exactMatch	mesh	D017824	Bone Cysts, Aneurysmal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018830	Kimura disease	skos:exactMatch	mesh	D000082242	Kimura Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018869	cobblestone lissencephaly	skos:exactMatch	mesh	D054222	Cobblestone Lissencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018878	branchiootic syndrome	skos:exactMatch	mesh	C537104	Branchiootic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018949	distal myopathy	skos:exactMatch	mesh	D049310	Distal Myopathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019107	Rh deficiency syndrome	skos:exactMatch	mesh	C562717	Rh Deficiency Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019155	Leydig cell hypoplasia	skos:exactMatch	mesh	C562567	Leydig Cell Hypoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019169	pyruvate dehydrogenase deficiency	skos:exactMatch	mesh	D015325	Pyruvate Dehydrogenase Complex Deficiency Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019353	Stargardt disease	skos:exactMatch	mesh	D000080362	Stargardt Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019669	hypochondrogenesis	skos:exactMatch	mesh	C563007	Hypochondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Terminal Transverse Defects of Arm	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0020806	sinoatrial block	skos:exactMatch	mesh	D012848	Sinoatrial Block	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021065	pleural neoplasm	skos:exactMatch	mesh	D010997	Pleural Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021092	fallopian tube neoplasm	skos:exactMatch	mesh	D005185	Fallopian Tube Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021106	laminopathy	skos:exactMatch	mesh	D000083083	Laminopathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021224	iris neoplasm	skos:exactMatch	mesh	D015811	Iris Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021234	spinal cord neoplasm	skos:exactMatch	mesh	D013120	Spinal Cord Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021253	gallbladder neoplasm	skos:exactMatch	mesh	D005706	Gallbladder Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0021662	bile duct neoplasm	skos:exactMatch	mesh	D001650	Bile Duct Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0022140	Charles bonnet syndrome	skos:exactMatch	mesh	D000075562	Charles Bonnet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0022208	crystal arthropathy	skos:exactMatch	mesh	D000070657	Crystal Arthropathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0023305	heavy metal poisoning	skos:exactMatch	mesh	D000075322	Heavy Metal Poisoning	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024264	hypothyroidism, congenital, nongoitrous, 2	skos:exactMatch	mesh	C566852	Hypothyroidism, Congenital, Nongoitrous, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024288	hyperbilirubinemia	skos:exactMatch	mesh	D006932	Hyperbilirubinemia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024332	perennial allergic rhinitis	skos:exactMatch	mesh	D012221	Rhinitis, Allergic, Perennial	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024361	circadian rhythm sleep disorder	skos:exactMatch	mesh	D020178	Sleep Disorders, Circadian Rhythm	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024465	surfactant metabolism dysfunction, pulmonary, 2	skos:exactMatch	mesh	C567048	Surfactant Metabolism Dysfunction, Pulmonary, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024559	aortic aneurysm, familial thoracic 1	skos:exactMatch	mesh	C562834	Aortic Aneurysm, Familial Thoracic 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024647	urolithiasis	skos:exactMatch	mesh	D052878	Urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024653	skull neoplasm	skos:exactMatch	mesh	D012888	Skull Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0026404	X inactivation, familial skewed, 1	skos:exactMatch	mesh	C564716	X Inactivation, Familial Skewed, 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0026426	X inactivation, familial skewed, 2	skos:exactMatch	mesh	C564572	X Inactivation, Familial Skewed, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0027091	xanthogranulomatous sialadenitis	skos:exactMatch	mesh	C536763	Xanthogranulomatous sialadenitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0030048	harderoporphyria	skos:exactMatch	mesh	C562816	Harderoporphyria	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0036591	adrenal cortex neoplasm	skos:exactMatch	mesh	D000306	Adrenal Cortex Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0037748	hyperlipoproteinemia	skos:exactMatch	mesh	D006951	Hyperlipoproteinemias	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0041161	endometrial hyperplasia	skos:exactMatch	mesh	D004714	Endometrial Hyperplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0041656	ST-elevation myocardial infarction	skos:exactMatch	mesh	D000072657	ST Elevation Myocardial Infarction	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0041751	multibacillary leprosy	skos:exactMatch	mesh	D056006	Leprosy, Multibacillary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0041752	paucibacillary leprosy	skos:exactMatch	mesh	D056005	Leprosy, Paucibacillary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0044877	paraneoplastic cerebellar degeneration	skos:exactMatch	mesh	D020362	Paraneoplastic Cerebellar Degeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0054868	meconium ileus	skos:exactMatch	mesh	D000074270	Meconium Ileus	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100053	anaphylaxis	skos:exactMatch	mesh	D000707	Anaphylaxis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100075	jaw fracture	skos:exactMatch	mesh	D007572	Jaw Fractures	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100115	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100120	vector-borne disease	skos:exactMatch	mesh	D000079426	Vector Borne Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100128	coinfection	skos:exactMatch	mesh	D060085	Coinfection	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100164	permanent neonatal diabetes mellitus	skos:exactMatch	mesh	C563425	Diabetes Mellitus, Permanent Neonatal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100192	liver failure	skos:exactMatch	mesh	D017093	Liver Failure	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100338	urinary tract infection	skos:exactMatch	mesh	D014552	Urinary Tract Infections	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100345	lactose intolerance	skos:exactMatch	mesh	D007787	Lactose Intolerance	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100350	neuronopathy, distal hereditary motor, type 5	skos:exactMatch	mesh	C563443	Neuronopathy, Distal Hereditary Motor, Type V	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100457	achalasia, familial esophageal	skos:exactMatch	mesh	C536011	Achalasia, familial esophageal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100482	extensively drug-resistant tuberculosis	skos:exactMatch	mesh	D054908	Extensively Drug-Resistant Tuberculosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0400005	refeeding syndrome	skos:exactMatch	mesh	D055677	Refeeding Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0600008	cytokine release syndrome	skos:exactMatch	mesh	D000080424	Cytokine Release Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0700064	aneuploidy	skos:exactMatch	mesh	D000782	Aneuploidy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0700065	trisomy	skos:exactMatch	mesh	D014314	Trisomy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0700086	uniparental disomy	skos:exactMatch	mesh	D024182	Uniparental Disomy	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	8000018	benign paroxysmal positional vertigo	skos:exactMatch	mesh	D065635	Benign Paroxysmal Positional Vertigo	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	8000019	vertigo, benign recurrent, 1	skos:exactMatch	mesh	C567620	Vertigo, Benign Recurrent, 1	manually_reviewed	orcid:0000-0001-9439-5346
 ncit	C1707	Voriconazole	skos:exactMatch	chebi	CHEBI:10023	voriconazole	manual	orcid:0000-0003-4423-4370
 ncit	C2160	Proteasome Inhibitor	skos:exactMatch	chebi	CHEBI:52726	proteasome inhibitor	manual	orcid:0000-0003-4423-4370
 ncit	C65538	Esomeprazole	skos:exactMatch	chebi	CHEBI:50275	esomeprazole	manual	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -6520,12 +6520,36 @@ mondo	0011713	melanoma-pancreatic cancer syndrome	skos:exactMatch	mesh	C563985	M
 mondo	0011826	glucocorticoid deficiency 2	skos:exactMatch	mesh	C564577	Glucocorticoid Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0011885	tubulointerstitial nephritis and uveitis syndrome	skos:exactMatch	mesh	C536922	Tubulointerstitial nephritis and uveitis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0011918	anxiety	skos:exactMatch	mesh	D001007	Anxiety	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012214	glucocorticoid deficiency 3	skos:exactMatch	mesh	C563776	Glucocorticoid Deficiency 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012217	Bruck syndrome 2	skos:exactMatch	mesh	C537407	Bruck syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012252	rhabdoid tumor predisposition syndrome 1	skos:exactMatch	mesh	C563738	Rhabdoid Tumor Predisposition Syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012270	Tukel syndrome	skos:exactMatch	mesh	C536925	Tukel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012287	Stickler syndrome, type I, nonsyndromic ocular	skos:exactMatch	mesh	C563709	Stickler Syndrome, Type I, Nonsyndromic Ocular	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012310	fibrosis of extraocular muscles, congenital, with synergistic divergence	skos:exactMatch	mesh	C566508	Fibrosis of Extraocular Muscles, Congenital, with Synergistic Divergence	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012400	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012408	microphthalmia, isolated, with coloboma 3	skos:exactMatch	mesh	C566447	Microphthalmia, Isolated, with Coloboma 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012425	corneal dystrophy, fuchs endothelial, 2	skos:exactMatch	mesh	C535479	Corneal dystrophy, Fuchs' endothelial, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012484	prosopagnosia, hereditary	skos:exactMatch	mesh	C537242	Prosopagnosia, hereditary	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0012522	diabetes mellitus, transient neonatal, 3	skos:exactMatch	mesh	C566432	Diabetes Mellitus, Transient Neonatal, 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013129	cone dystrophy 4	skos:exactMatch	mesh	C567758	Cone Dystrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013199	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013203	corneal dystrophy, Fuchs endothelial, 3	skos:exactMatch	mesh	C567678	Corneal Dystrophy, Fuchs Endothelial, 3	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013204	corneal dystrophy, Fuchs endothelial, 4	skos:exactMatch	mesh	C567677	Corneal Dystrophy, Fuchs Endothelial, 4	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013205	corneal dystrophy, fuchs endothelial, 5	skos:exactMatch	mesh	C567676	Corneal Dystrophy, Fuchs Endothelial, 5	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013206	corneal dystrophy, Fuchs endothelial, 6	skos:exactMatch	mesh	C567675	Corneal Dystrophy, Fuchs Endothelial, 6	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0013207	corneal dystrophy, fuchs endothelial, 7	skos:exactMatch	mesh	C567674	Corneal Dystrophy, Fuchs Endothelial, 7	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015240	digitotalar dysmorphism	skos:exactMatch	mesh	C565097	Digitotalar Dysmorphism	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015281	atrial standstill	skos:exactMatch	mesh	C563984	Atrial Standstill	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0015451	univentricular heart	skos:exactMatch	mesh	D000080039	Univentricular Heart	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015467	craniosynostosis, Philadelphia type	skos:exactMatch	mesh	C563368	Craniosynostosis, Philadelphia Type	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0015564	Castleman disease	skos:exactMatch	mesh	D005871	Castleman Disease	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015993	cone-rod dystrophy	skos:exactMatch	mesh	D000071700	Cone-Rod Dystrophies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0015995	melorheostosis with osteopoikilosis	skos:exactMatch	mesh	C563593	Melorheostosis with Osteopoikilosis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016101	neurolymphomatosis	skos:exactMatch	mesh	D000077162	Neurolymphomatosis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016217	mal de Debarquement	skos:exactMatch	mesh	C537840	Mal de debarquement	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016295	neuronal ceroid lipofuscinosis	skos:exactMatch	mesh	D009472	Neuronal Ceroid-Lipofuscinoses	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016301	congenitally corrected transposition of the great arteries	skos:exactMatch	mesh	D000080041	Congenitally Corrected Transposition of the Great Arteries	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0016366	maternal phenylketonuria	skos:exactMatch	mesh	D017042	Phenylketonuria, Maternal	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016567	locked-in syndrome	skos:exactMatch	mesh	D000080422	Locked-In Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016607	odontohypophosphatasia	skos:exactMatch	mesh	C564146	Odontohypophosphatasia	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0016798	ataxia neuropathy spectrum	skos:exactMatch	mesh	C579922	Ataxia Neuropathy Spectrum	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6535,13 +6559,17 @@ mondo	0017169	multiple endocrine neoplasia	skos:exactMatch	mesh	D009377	Multiple
 mondo	0017198	osteopetrosis	skos:exactMatch	mesh	D010022	Osteopetrosis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0017267	self-healing collodion baby	skos:exactMatch	mesh	C565473	Self-Healing Collodion Baby	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0017349	myopericytoma	skos:exactMatch	mesh	D000077777	Myopericytoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0017715	3-hydroxyacyl-CoA dehydrogenase deficiency	skos:exactMatch	mesh	C535310	3-Hydroxyacyl-CoA Dehydrogenase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0017999	fatty acid hydroxylase-associated neurodegeneration	skos:exactMatch	mesh	C580102	Fatty Acid Hydroxylase-Associated Neurodegeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018072	persistent truncus arteriosus	skos:exactMatch	mesh	D014339	Truncus Arteriosus, Persistent	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018082	aorto-ventricular tunnel	skos:exactMatch	mesh	D000082903	Aortico-Ventricular Tunnel	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018135	oculocutaneous albinism type 1	skos:exactMatch	mesh	C537728	Oculocutaneous albinism type 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018154	Madelung deformity	skos:exactMatch	mesh	C562398	Madelung Deformity	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018226	infantile epileptic-dyskinetic encephalopathy	skos:exactMatch	mesh	C567924	Infantile Epileptic-Dyskinetic Encephalopathy	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018338	activated PI3K-delta syndrome	skos:exactMatch	mesh	C585640	Activated PI3K-delta Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018363	focal facial dermal dysplasia	skos:exactMatch	mesh	C537068	Focal facial dermal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018668	scedosporiosis	skos:exactMatch	mesh	C000656924	scedosporiosis	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0018781	KID syndrome	skos:exactMatch	mesh	C536168	Keratitis, Ichthyosis, and Deafness (KID) Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018815	aneurysmal bone cyst	skos:exactMatch	mesh	D017824	Bone Cysts, Aneurysmal	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018830	Kimura disease	skos:exactMatch	mesh	D000082242	Kimura Disease	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0018869	cobblestone lissencephaly	skos:exactMatch	mesh	D054222	Cobblestone Lissencephaly	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6556,6 +6584,8 @@ mondo	0019760	terminal transverse defects of arm	skos:exactMatch	mesh	C565681	Te
 mondo	0019804	tracheomalacia	skos:exactMatch	mesh	D055090	Tracheomalacia	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0019978	Robinow syndrome	skos:exactMatch	mesh	C562492	Robinow Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0020540	ovarian gynandroblastoma	skos:exactMatch	mesh	C538459	Ovarian gynandroblastoma	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0020756	migraine, familial hemiplegic, 1	skos:exactMatch	mesh	C536890	Hemiplegic migraine, familial type 1	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0020792	dwarfism with tall vertebrae	skos:exactMatch	mesh	C535725	Dwarfism tall vertebrae	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0020806	sinoatrial block	skos:exactMatch	mesh	D012848	Sinoatrial Block	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0021065	pleural neoplasm	skos:exactMatch	mesh	D010997	Pleural Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0021092	fallopian tube neoplasm	skos:exactMatch	mesh	D005185	Fallopian Tube Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6566,12 +6596,14 @@ mondo	0021253	gallbladder neoplasm	skos:exactMatch	mesh	D005706	Gallbladder Neop
 mondo	0021662	bile duct neoplasm	skos:exactMatch	mesh	D001650	Bile Duct Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0022140	Charles bonnet syndrome	skos:exactMatch	mesh	D000075562	Charles Bonnet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0022208	crystal arthropathy	skos:exactMatch	mesh	D000070657	Crystal Arthropathies	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0023203	Fuchs atrophia gyrata chorioideae et retinae	skos:exactMatch	mesh	C538071	Fuchs atrophia gyrata chorioideae et retinae	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0023305	heavy metal poisoning	skos:exactMatch	mesh	D000075322	Heavy Metal Poisoning	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024264	hypothyroidism, congenital, nongoitrous, 2	skos:exactMatch	mesh	C566852	Hypothyroidism, Congenital, Nongoitrous, 2	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024288	hyperbilirubinemia	skos:exactMatch	mesh	D006932	Hyperbilirubinemia	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024332	perennial allergic rhinitis	skos:exactMatch	mesh	D012221	Rhinitis, Allergic, Perennial	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024361	circadian rhythm sleep disorder	skos:exactMatch	mesh	D020178	Sleep Disorders, Circadian Rhythm	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024465	surfactant metabolism dysfunction, pulmonary, 2	skos:exactMatch	mesh	C567048	Surfactant Metabolism Dysfunction, Pulmonary, 2	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0024543	brittle cornea syndrome 1	skos:exactMatch	mesh	C536192	Brittle cornea syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024559	aortic aneurysm, familial thoracic 1	skos:exactMatch	mesh	C562834	Aortic Aneurysm, Familial Thoracic 1	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024647	urolithiasis	skos:exactMatch	mesh	D052878	Urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0024653	skull neoplasm	skos:exactMatch	mesh	D012888	Skull Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6593,6 +6625,7 @@ mondo	0100115	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flacc
 mondo	0100120	vector-borne disease	skos:exactMatch	mesh	D000079426	Vector Borne Diseases	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0100128	coinfection	skos:exactMatch	mesh	D060085	Coinfection	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0100164	permanent neonatal diabetes mellitus	skos:exactMatch	mesh	C563425	Diabetes Mellitus, Permanent Neonatal	manually_reviewed	orcid:0000-0001-9439-5346
+mondo	0100185	immune reconstitution inflammatory syndrome	skos:exactMatch	mesh	D054019	Immune Reconstitution Inflammatory Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0100192	liver failure	skos:exactMatch	mesh	D017093	Liver Failure	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0100338	urinary tract infection	skos:exactMatch	mesh	D014552	Urinary Tract Infections	manually_reviewed	orcid:0000-0001-9439-5346
 mondo	0100345	lactose intolerance	skos:exactMatch	mesh	D007787	Lactose Intolerance	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -139,6 +139,8 @@ class InvalidNormIdentifier(InvalidIdentifier):
 
 def check_valid_prefix_id(prefix, identifier):
     """Check the prefix/identifier pair is valid."""
+    if prefix == 'mondo':
+        breakpoint()
     resource = bioregistry.get_resource(prefix)
     if resource is None:
         raise InvalidPrefix(prefix)

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -139,8 +139,6 @@ class InvalidNormIdentifier(InvalidIdentifier):
 
 def check_valid_prefix_id(prefix, identifier):
     """Check the prefix/identifier pair is valid."""
-    if prefix == 'mondo':
-        breakpoint()
     resource = bioregistry.get_resource(prefix)
     if resource is None:
         raise InvalidPrefix(prefix)
@@ -148,6 +146,7 @@ def check_valid_prefix_id(prefix, identifier):
         norm_identifier = resource.miriam_standardize_identifier(identifier)
         if norm_identifier != identifier:
             raise InvalidNormIdentifier(prefix, identifier, norm_identifier)
+        return
     miriam_pattern = resource.miriam.get("pattern") if resource.miriam else None
     if not miriam_pattern:
         pattern = resource.get_pattern_re()


### PR DESCRIPTION
This PR predicts and then curates around 200 new mappings between MONDO and MeSH. These are restricted to cases where there isn't already a direct mapping in MONDO or an indirect xref path from MONDO (via e.g., DOID) to MeSH. By adding a `return` after the first check to `check_valid_prefix_id`, this resolves #94 but I'm not sure if this is the right solution to that.