### PR TITLE
Curate additional DOID-MESH mappings and contribute to DOID

### DIFF
--- a/scripts/add_mesh_xrefs_to_doid_owl.py
+++ b/scripts/add_mesh_xrefs_to_doid_owl.py
@@ -1,0 +1,139 @@
+"""This script adds newly inferred cross-references for DOID.
+
+These are directly added to the version controlled DOID OWL file.
+"""
+import csv
+import obonet
+from biomappings import load_mappings
+
+EDITABLE_OWL_PATH = "/Users/ben/src/HumanDiseaseOntology/src/ontology/doid-edit.owl"
+OBO_PATH = "/Users/ben/src/HumanDiseaseOntology/src/ontology/HumanDO.obo"
+REVIEW_PATH = "/Users/ben/src/HumanDiseaseOntology/doid_mesh_review.tsv"
+
+# Get the DOID ontology
+g = obonet.read_obo(
+    "https://raw.githubusercontent.com/DiseaseOntology/"
+    "HumanDiseaseOntology/main/src/ontology/HumanDO.obo"
+)
+
+
+def add_xref(lines, node, xref):
+    """Add xrefs to an appropriate place in the OWL file."""
+    node_owl = node.replace(":", "_")
+    look_for_xref = False
+    start_xref_idx = None
+    def_idx = None
+    xref_entries = []
+    for idx, line in enumerate(lines):
+        # First, find the class with the given ID and start looking for xrefs
+        if line.startswith("# Class: obo:%s" % node_owl):
+            blank_counter = 0
+            look_for_xref = True
+            def_idx = idx + 2
+            continue
+        # If we are already looking for xrefs after the header
+        if look_for_xref:
+            # Note that there is always a blank line right after this header, and
+            # also after the block corresponding to the entry ends. So we need
+            # to be able to tell whether we are at the first or second blank line
+            # after the header.
+            if not line.strip():
+                if not blank_counter:
+                    blank_counter += 1
+                    continue
+                else:
+                    break
+            # If we find some xrefs, we keep track of those
+            if line.startswith("AnnotationAssertion(oboInOwl:hasDbXref obo"):
+                if not start_xref_idx:
+                    start_xref_idx = idx
+                xref_entries.append(line)
+            # If we found any xrefs but now there is a different line, we finish
+            elif start_xref_idx and not line.startswith("AnnotationAssertion(oboInOwl:hasDbXref"):
+                break
+    # If we never found any existing xrefs then we will put the new xref
+    # after the definition
+    if start_xref_idx is None:
+        start_xref_idx = def_idx + 1
+    # We now have to render the xref string and sort xrefs alphabetically
+    # to make sure we put the new one in the right place
+    xref_str = 'AnnotationAssertion(oboInOwl:hasDbXref obo:%s "%s"^^xsd:string)\n' % (
+        node_owl,
+        xref,
+    )
+    xref_entries.append(xref_str)
+    xref_entries = sorted(xref_entries)
+    xr_idx = xref_entries.index(xref_str)
+    lines.insert(start_xref_idx + xr_idx, xref_str)
+    return lines
+
+
+if __name__ == "__main__":
+    # There are some curations that are redundant since DOID already mapped
+    # these nodes to MESH. We figure out what these are so we can avoid
+    # adding them.
+    doid_already_mapped = set()
+    g = obonet.read_obo(OBO_PATH)
+    for node, data in g.nodes(data=True):
+        # Skip external entries
+        if not node.startswith("DOID"):
+            continue
+        # Make sure we have a name
+        if "name" not in data:
+            continue
+        # Get existing xrefs as a standardized dict
+        xrefs = dict([xref.split(":", maxsplit=1) for xref in data.get("xref", [])])
+        # If there are already MESH mappings, we keep track of that
+        if "MESH" in xrefs:
+            doid_already_mapped.add(node)
+
+    # We now load mappings curated in Biomappings
+    mappings = load_mappings()
+    doid_mappings = [
+        (m["source identifier"], m["target identifier"], m)
+        for m in mappings
+        if (
+            m["source prefix"] == "doid"
+            and m["target prefix"] == "mesh"
+            and m["source identifier"] not in doid_already_mapped
+        )
+    ]
+    # Make sure we get and standardize the order of mappings in both directions
+    doid_mappings += [
+        (m["target identifier"], m["source identifier"], m)
+        for m in mappings
+        if (
+            m["source prefix"] == "mesh"
+            and m["target prefix"] == "doid"
+            and m["target identifier"] not in doid_already_mapped
+        )
+    ]
+
+    # Read the OWL file
+    with open(EDITABLE_OWL_PATH, "r") as fh:
+        lines = fh.readlines()
+
+    review_cols = [
+        "source prefix",
+        "source identifier",
+        "source name",
+        "relation",
+        "target prefix",
+        "target identifier",
+        "target name",
+        "type",
+        "source",
+    ]
+    review_rows = [review_cols]
+    # Add all the xrefs to the OWL, simultaneously add xrefs to a review TSV
+    for do_id, mesh_id, mapping in doid_mappings:
+        lines = add_xref(lines, do_id, "MESH:" + mesh_id)
+        review_rows.append([mapping[c] for c in review_cols])
+
+    # Dump the new review TSV and OWL file
+    with open(REVIEW_PATH, "w") as fh:
+        writer = csv.writer(fh, delimiter="\t")
+        writer.writerows(review_rows)
+
+    with open(EDITABLE_OWL_PATH, "w") as fh:
+        fh.writelines(lines)

--- a/scripts/add_mesh_xrefs_to_doid_owl.py
+++ b/scripts/add_mesh_xrefs_to_doid_owl.py
@@ -3,7 +3,9 @@
 These are directly added to the version controlled DOID OWL file.
 """
 import csv
+
 import obonet
+
 from biomappings import load_mappings
 
 EDITABLE_OWL_PATH = "/Users/ben/src/HumanDiseaseOntology/src/ontology/doid-edit.owl"

--- a/scripts/generate_doid_mappings.py
+++ b/scripts/generate_doid_mappings.py
@@ -29,7 +29,6 @@ def main():
         # "ordo",
         # "cido"
     ]
-
     custom_filter = get_custom_filter(prefix, targets)
     append_gilda_predictions(
         prefix,

--- a/scripts/generate_doid_mappings.py
+++ b/scripts/generate_doid_mappings.py
@@ -29,6 +29,7 @@ def main():
         # "ordo",
         # "cido"
     ]
+
     custom_filter = get_custom_filter(prefix, targets)
     append_gilda_predictions(
         prefix,

--- a/scripts/generate_doid_mesh_mappings.py
+++ b/scripts/generate_doid_mesh_mappings.py
@@ -1,0 +1,94 @@
+"""Generate mappings using Gilda from DOID to MeSH."""
+from collections import Counter
+
+import gilda
+import obonet
+from indra.databases import mesh_client
+from indra.ontology.standardize import standardize_db_refs
+from indra.tools.fix_invalidities import fix_invalidities_db_refs
+
+from biomappings import load_mappings, load_unsure, load_false_mappings
+from biomappings.resources import PredictionTuple, append_prediction_tuples
+
+# Get the DOID ontology
+g = obonet.read_obo(
+    "https://raw.githubusercontent.com/DiseaseOntology/"
+    "HumanDiseaseOntology/main/src/ontology/HumanDO.obo"
+)
+
+# Make sure we know which mappings have already been curated
+curated_mappings = set()
+for m in list(load_mappings()) + list(load_unsure()) + list(load_false_mappings()):
+    if m["source prefix"] == "doid" and m["target prefix"] == "mesh":
+        curated_mappings.add(m["source identifier"])
+    elif m["target prefix"] == "doid" and m["source prefix"] == "mesh":
+        curated_mappings.add(m["target identifier"])
+
+
+# We now iterate over all DOID entries and check for possible mappings
+mappings = {}
+existing_refs_to_mesh = set()
+already_mappable = set()
+for node, data in g.nodes(data=True):
+    # Skip external entries
+    if not node.startswith("DOID"):
+        continue
+    # Make sure we have a name
+    if "name" not in data:
+        continue
+    # Skip if already curated
+    if node in curated_mappings:
+        continue
+    # Get existing xrefs as a standardized dict
+    xrefs = [xref.split(":", maxsplit=1) for xref in data.get("xref", [])]
+    xrefs_dict = fix_invalidities_db_refs(dict(xrefs))
+    standard_refs = standardize_db_refs(xrefs_dict)
+    # If there are already MESH mappings, we keep track of that
+    if "MESH" in standard_refs:
+        already_mappable.add(node)
+    existing_refs_to_mesh |= {id for ns, id in standard_refs.items() if ns == "MESH"}
+    # We can now ground the name and specifically look for MESH matches
+    matches = gilda.ground(data["name"], namespaces=["MESH"])
+    # If we got a match, we add the MESH ID as a mapping
+    if matches:
+        for grounding in matches[0].get_groundings():
+            if grounding[0] == "MESH":
+                mappings[node] = matches[0].term.id
+
+
+print("Found %d DOID->MESH mappings." % len(mappings))
+
+# We makes sure that (i) the node is not already mappable to MESH and that
+# (ii) there isn't some other node that was not already mapped to the
+# given MESH ID
+mappings = {
+    k: v
+    for k, v in mappings.items()
+    if v not in existing_refs_to_mesh and k not in already_mappable
+}
+
+# We now need to make sure that we don't reuse the same MESH ID across
+# multiple predicted mappings
+cnt = Counter(mappings.values())
+mappings = {k: v for k, v in mappings.items() if cnt[v] == 1}
+
+print("Found %d filtered DOID->MESH mappings." % len(mappings))
+
+# We can now add the predictions
+predictions = []
+for doid, mesh_id in mappings.items():
+    pred = PredictionTuple(
+        target_prefix="doid",
+        target_identifier=doid[5:],
+        target_name=g.nodes[doid]["name"],
+        relation="skos:exactMatch",
+        source_prefix="mesh",
+        source_id=mesh_id,
+        source_name=mesh_client.get_mesh_name(mesh_id),
+        type="lexical",
+        confidence=0.9,
+        source="generate_doid_mesh_mappings.py",
+    )
+    predictions.append(pred)
+
+append_prediction_tuples(predictions, deduplicate=True, sort=True)

--- a/scripts/generate_doid_mesh_mappings.py
+++ b/scripts/generate_doid_mesh_mappings.py
@@ -7,7 +7,7 @@ from indra.databases import mesh_client
 from indra.ontology.standardize import standardize_db_refs
 from indra.tools.fix_invalidities import fix_invalidities_db_refs
 
-from biomappings import load_mappings, load_unsure, load_false_mappings
+from biomappings import load_false_mappings, load_mappings, load_unsure
 from biomappings.resources import PredictionTuple, append_prediction_tuples
 
 # Get the DOID ontology

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     pyyaml
     tqdm
     pystow>=0.2.7
-    bioregistry>=0.4.29
+    bioregistry>=0.5.104
 
 zip_safe = false
 include_package_data = True

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -366,6 +366,7 @@ mesh	C535442	Bile acid synthesis defect, congenital, 1	skos:exactMatch	doid	DOID
 mesh	C535536	Iridogoniodysgenesis, dominant type	skos:exactMatch	doid	DOID:0050786	iridogoniodysgenesis syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535837	Pancreatic carcinoma, familial	skos:exactMatch	doid	DOID:4905	pancreatic carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535847	Hay-Wells syndrome	skos:exactMatch	doid	DOID:0090119	ankyloblepharon-ectodermal defects-cleft lip/palate syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536133	Meckel syndrome type 1	skos:exactMatch	doid	0050778	Meckel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536192	Brittle cornea syndrome 1	skos:exactMatch	doid	DOID:14775	brittle cornea syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536277	Idiopathic dilation cardiomyopathy	skos:exactMatch	doid	DOID:0110429	dilated cardiomyopathy 1H	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536300	Partington X-linked mental retardation syndrome	skos:exactMatch	doid	DOID:14744	Partington syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -421,6 +422,7 @@ mesh	D003924	Diabetes Mellitus, Type 2	skos:exactMatch	doid	DOID:0050524	maturit
 mesh	D003925	Diabetic Angiopathies	skos:exactMatch	doid	DOID:10182	diabetic peripheral angiopathy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D004407	Dysgerminoma	skos:exactMatch	doid	DOID:5511	dysgerminoma of ovary	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D004410	Dyslexia	skos:exactMatch	doid	DOID:13365	reading disorder	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D004697	Endocarditis, Bacterial	skos:exactMatch	doid	0060000	infective endocarditis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004932	Esophageal and Gastric Varices	skos:exactMatch	doid	DOID:112	esophageal varix	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D005319	Fetal Hemoglobin	skos:exactMatch	efo	0004576	fetal hemoglobin measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D005351	Fibromatosis, Gingival	skos:exactMatch	doid	DOID:0060466	gingival fibromatosis	manually_reviewed	orcid:0000-0003-1307-2508

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -388,7 +388,6 @@ mesh	C567200	Immunodeficiency, Hypogammaglobulinemia, and Reduced B Cells	skos:e
 mesh	C567484	Mental Retardation, X-Linked, Syndromic, Christianson Type	skos:exactMatch	doid	DOID:0060825	Christianson syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567738	Neuropathy, Hereditary Sensory And Autonomic, Type IIB	skos:exactMatch	doid	DOID:0070150	hereditary sensory and autonomic neuropathy type 2B	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C579934	Autosomal Recessive Cerebellar Ataxia Type 1	skos:exactMatch	doid	DOID:0111618	autosomal recessive spinocerebellar ataxia 8	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C580012	Congenital Fibrosis of the Extraocular Muscles	skos:exactMatch	doid	DOID:0080143	congenital fibrosis of the extraocular muscles	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C580473	Succinate-Coa Ligase Deficiency	skos:exactMatch	doid	DOID:0080124	mitochondrial DNA depletion syndrome 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C584135	endotrophin	skos:exactMatch	ncit	C165979	Pro-C6 Measurement	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000071636	Protein Phosphatase 2C	skos:exactMatch	hgnc	9279	PDP1	manually_reviewed	orcid:0000-0001-9439-5346
@@ -434,7 +433,6 @@ mesh	D006441	Hemoglobin A	skos:exactMatch	efo	0009208	Hemoglobin A Measurement	m
 mesh	D006443	Hemoglobin A2	skos:exactMatch	efo	0005845	hemoglobin A2 measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D006451	Hemoglobin, Sickle	skos:exactMatch	efo	0009223	Hemoglobin S Measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D006480	Hemorrhagic Fever with Renal Syndrome	skos:exactMatch	doid	DOID:0050200	Korean hemorrhagic fever	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	D006519	Hepatitis, Alcoholic	skos:exactMatch	doid	DOID:12351	alcoholic hepatitis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D006593	Hexokinase	skos:exactMatch	go	GO:0004396	hexokinase activity	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006646	Histiocytosis, Langerhans-Cell	skos:exactMatch	doid	DOID:2571	Langerhans-cell histiocytosis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D007014	Hypophosphatasia	skos:exactMatch	doid	DOID:0110915	childhood hypophosphatasia	manually_reviewed	orcid:0000-0003-1307-2508

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -366,7 +366,7 @@ mesh	C535442	Bile acid synthesis defect, congenital, 1	skos:exactMatch	doid	DOID
 mesh	C535536	Iridogoniodysgenesis, dominant type	skos:exactMatch	doid	DOID:0050786	iridogoniodysgenesis syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535837	Pancreatic carcinoma, familial	skos:exactMatch	doid	DOID:4905	pancreatic carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535847	Hay-Wells syndrome	skos:exactMatch	doid	DOID:0090119	ankyloblepharon-ectodermal defects-cleft lip/palate syndrome	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C536133	Meckel syndrome type 1	skos:exactMatch	doid	0050778	Meckel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C536133	Meckel syndrome type 1	skos:exactMatch	doid	DOID:0050778	Meckel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536192	Brittle cornea syndrome 1	skos:exactMatch	doid	DOID:14775	brittle cornea syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536277	Idiopathic dilation cardiomyopathy	skos:exactMatch	doid	DOID:0110429	dilated cardiomyopathy 1H	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536300	Partington X-linked mental retardation syndrome	skos:exactMatch	doid	DOID:14744	Partington syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -422,7 +422,7 @@ mesh	D003924	Diabetes Mellitus, Type 2	skos:exactMatch	doid	DOID:0050524	maturit
 mesh	D003925	Diabetic Angiopathies	skos:exactMatch	doid	DOID:10182	diabetic peripheral angiopathy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D004407	Dysgerminoma	skos:exactMatch	doid	DOID:5511	dysgerminoma of ovary	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D004410	Dyslexia	skos:exactMatch	doid	DOID:13365	reading disorder	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	D004697	Endocarditis, Bacterial	skos:exactMatch	doid	0060000	infective endocarditis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004697	Endocarditis, Bacterial	skos:exactMatch	doid	DOID:0060000	infective endocarditis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D004932	Esophageal and Gastric Varices	skos:exactMatch	doid	DOID:112	esophageal varix	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D005319	Fetal Hemoglobin	skos:exactMatch	efo	0004576	fetal hemoglobin measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D005351	Fibromatosis, Gingival	skos:exactMatch	doid	DOID:0060466	gingival fibromatosis	manually_reviewed	orcid:0000-0003-1307-2508

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -106,8 +106,6 @@ cl	CL:2000004	pituitary gland cell	skos:exactMatch	mesh	D010902	Pituitary Gland	
 cl	CL:2000021	sebaceous gland cell	skos:exactMatch	mesh	D012627	Sebaceous Glands	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:2000022	cardiac septum cell	skos:exactMatch	mesh	D006346	Heart Septum	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:2000030	hypothalamus cell	skos:exactMatch	mesh	D007031	Hypothalamus	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080046	Stickler syndrome	skos:exactMatch	mesh	C537492	Stickler syndrome, type 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080939	hereditary angioedema type I	skos:exactMatch	mesh	D056829	Hereditary Angioedema Types I and II	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	mesh	D006394	Hemangiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	umls	C0018923	Hemangiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	umls	C0278592	Adult Angiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
@@ -161,6 +159,7 @@ doid	DOID:0080546	non-alcoholic fatty liver	skos:exactMatch	mesh	D065626	Non-alc
 doid	DOID:0080547	non-alcoholic steatohepatitis	skos:exactMatch	mesh	D065626	Non-alcoholic Fatty Liver Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080748	chronic inducible urticaria	skos:exactMatch	mesh	D000080223	Chronic Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080749	chronic spontaneous urticaria	skos:exactMatch	mesh	D000080223	Chronic Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080939	hereditary angioedema type I	skos:exactMatch	mesh	D056829	Hereditary Angioedema Types I and II	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111135	congenital generalized lipodystrophy type 1	skos:exactMatch	mesh	D052497	Lipodystrophy, Congenital Generalized	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111136	congenital generalized lipodystrophy type 2	skos:exactMatch	mesh	D052497	Lipodystrophy, Congenital Generalized	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1024	leprosy	skos:exactMatch	umls	C0051981	leprosy vaccine	manually_reviewed	orcid:0000-0003-4423-4370
@@ -178,6 +177,7 @@ doid	DOID:1498	cholera	skos:exactMatch	umls	C0008359	cholera vaccine	manually_re
 doid	DOID:1586	rheumatic fever	skos:exactMatch	umls	C1548484	rheumatic fever vaccine	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:1909	melanoma	skos:exactMatch	umls	C0796561	Melanoma vaccine	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:2043	hepatitis B	skos:exactMatch	umls	C0062527	hepatitis B surface antigen vaccine	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:3479	uveal cancer	skos:exactMatch	mesh	D014604	Uveal Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:3482	plague	skos:exactMatch	umls	C0032066	Plague Vaccine	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:3910	lung adenocarcinoma	skos:exactMatch	efo	0005288	non-small cell lung adenocarcinoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4552	large cell carcinoma	skos:exactMatch	efo	0003050	large cell lung carcinoma	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -106,6 +106,8 @@ cl	CL:2000004	pituitary gland cell	skos:exactMatch	mesh	D010902	Pituitary Gland	
 cl	CL:2000021	sebaceous gland cell	skos:exactMatch	mesh	D012627	Sebaceous Glands	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:2000022	cardiac septum cell	skos:exactMatch	mesh	D006346	Heart Septum	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:2000030	hypothalamus cell	skos:exactMatch	mesh	D007031	Hypothalamus	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080046	Stickler syndrome	skos:exactMatch	mesh	C537492	Stickler syndrome, type 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080939	hereditary angioedema type I	skos:exactMatch	mesh	D056829	Hereditary Angioedema Types I and II	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	mesh	D006394	Hemangiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	umls	C0018923	Hemangiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0001816	angiosarcoma	skos:exactMatch	umls	C0278592	Adult Angiosarcoma	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -132,9 +132,12 @@ doid	DOID:0050575	D-2-hydroxyglutaric aciduria	skos:exactMatch	mesh	C535306	2-Hy
 doid	DOID:0050575	D-2-hydroxyglutaric aciduria	skos:exactMatch	umls	C2746066	Combined D-2- and L-2-hydroxyglutaric aciduria	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050577	cranioectodermal dysplasia	skos:exactMatch	umls	C0432235	CRANIOECTODERMAL DYSPLASIA 1	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050580	hereditary lymphedema	skos:exactMatch	mesh	D008209	Lymphedema	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0050650	familial atrial fibrillation	skos:exactMatch	mesh	D001281	Atrial Fibrillation	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050665	fetal alcohol syndrome	skos:exactMatch	mesh	D063647	Fetal Alcohol Spectrum Disorders	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050666	partial fetal alcohol syndrome	skos:exactMatch	mesh	D063647	Fetal Alcohol Spectrum Disorders	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050667	alcohol-related neurodevelopmental disorder	skos:exactMatch	mesh	D063647	Fetal Alcohol Spectrum Disorders	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0050672	dyskinetic cerebral palsy	skos:exactMatch	mesh	D002547	Cerebral Palsy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0050673	mixed cerebral palsy	skos:exactMatch	mesh	D002547	Cerebral Palsy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050685	small cell carcinoma	skos:exactMatch	umls	C0149925	Small cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0050882	spinocerebellar ataxia type 5	skos:exactMatch	mesh	D020754	Spinocerebellar Ataxias	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050954	spinocerebellar ataxia type 1	skos:exactMatch	mesh	D020754	Spinocerebellar Ataxias	manually_reviewed	orcid:0000-0001-9439-5346
@@ -148,6 +151,9 @@ doid	DOID:0060141	finger agnosia	skos:exactMatch	mesh	D000377	Agnosia	manually_r
 doid	DOID:0060151	tactile agnosia	skos:exactMatch	mesh	D000377	Agnosia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060152	time agnosia	skos:exactMatch	mesh	D000377	Agnosia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060153	topographical agnosia	skos:exactMatch	mesh	D000377	Agnosia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070197	distal myopathy 1	skos:exactMatch	mesh	D049310	Distal Myopathies	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070340	classic citrullinemia	skos:exactMatch	mesh	D020159	Citrullinemia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080046	Stickler syndrome	skos:exactMatch	mesh	C537492	Stickler syndrome, type 1	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080333	aortic valve disease 1	skos:exactMatch	mesh	D000082882	Bicuspid Aortic Valve Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080546	non-alcoholic fatty liver	skos:exactMatch	mesh	D065626	Non-alcoholic Fatty Liver Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080547	non-alcoholic steatohepatitis	skos:exactMatch	mesh	D065626	Non-alcoholic Fatty Liver Disease	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2412,6 +2412,138 @@ cl	CL:0008002	skeletal muscle fiber	skos:exactMatch	mesh	D018485	Muscle Fibers, 
 cl	CL:0010003	epithelial cell of alveolus of lung	skos:exactMatch	mesh	D056809	Alveolar Epithelial Cells	manual	orcid:0000-0001-9439-5346
 cl	CL:0010017	zygote	skos:exactMatch	mesh	D015053	Zygote	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0010021	cardiac myoblast	skos:exactMatch	mesh	D032386	Myoblasts, Cardiac	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060046	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060259	renal-hepatic-pancreatic dysplasia	skos:exactMatch	mesh	C567142	Renal-Hepatic-Pancreatic Dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060283	peeling skin syndrome	skos:exactMatch	mesh	C564818	Peeling Skin Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060297	complement component 4a deficiency	skos:exactMatch	mesh	C565167	Complement Component 4a Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060299	complement component 6 deficiency	skos:exactMatch	mesh	C567307	Complement Component 6 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060300	complement component 7 deficiency	skos:exactMatch	mesh	C566443	Complement Component 7 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060303	complement component 9 deficiency	skos:exactMatch	mesh	C565165	C9 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060413	chromosome 22q11.2 deletion syndrome, distal	skos:exactMatch	mesh	C567511	Chromosome 22q11.2 Deletion Syndrome, Distal	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060415	chromosome 2p16.1-p15 deletion syndrome	skos:exactMatch	mesh	C567289	Chromosome 2p16.1-P15 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060416	chromosome 2q31.2 deletion syndrome	skos:exactMatch	mesh	C567344	Chromosome 2q31.2 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060422	chromosome 6pter-p24 deletion syndrome	skos:exactMatch	mesh	C567239	Chromosome 6pter-P24 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060432	chromosome 17p13.3 duplication syndrome	skos:exactMatch	mesh	C567705	Chromosome 17p13.3 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060435	chromosome 1q21.1 duplication syndrome	skos:exactMatch	mesh	C567290	Chromosome 1q21.1 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060460	chromosome 5p13 duplication syndrome	skos:exactMatch	mesh	C567717	Chromosome 5p13 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060461	chromosome Xp11.23-p11.22 duplication syndrome	skos:exactMatch	mesh	C567585	Chromosome Xp11.23-P11.22 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060540	Hermansky-Pudlak syndrome 2	skos:exactMatch	mesh	C537709	Hermansky Pudlak syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060564	spinal disease	skos:exactMatch	mesh	D013122	Spinal Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060580	Noonan syndrome 2	skos:exactMatch	mesh	C548081	Noonan Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060581	Noonan syndrome 3	skos:exactMatch	mesh	C537847	Noonan syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060582	Noonan syndrome 4	skos:exactMatch	mesh	C548082	Noonan Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060583	Noonan syndrome 5	skos:exactMatch	mesh	C548083	Noonan Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060584	Noonan syndrome 6	skos:exactMatch	mesh	C548084	Noonan Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060602	alpha-methylacyl-CoA racemase deficiency	skos:exactMatch	mesh	C565768	Alpha-Methylacyl-CoA Racemase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060604	ankyloglossia	skos:exactMatch	mesh	D000072676	Ankyloglossia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060609	microcephalic osteodysplastic primordial dwarfism type II	skos:exactMatch	mesh	C565898	Microcephalic Osteodysplastic Primordial Dwarfism, Type II	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060611	abdominal obesity-metabolic syndrome	skos:exactMatch	mesh	C535554	Abdominal obesity metabolic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060668	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060746	basal laminar drusen	skos:exactMatch	mesh	C563034	Basal Laminar Drusen	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060769	T-cell immunodeficiency, congenital alopecia, and nail dystrophy	skos:exactMatch	mesh	C536781	T-cell immunodeficiency, congenital alopecia and nail dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0060858	hypotonia-cystinuria syndrome	skos:exactMatch	mesh	C564710	Hypotonia-Cystinuria Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0070007	Seckel syndrome 1	skos:exactMatch	mesh	C537533	Seckel syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0070013	Seckel syndrome 2	skos:exactMatch	mesh	C537534	Seckel syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0070096	oculocutaneous albinism type II	skos:exactMatch	mesh	C537730	Oculocutaneous albinism type 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0070344	ocular tuberculosis	skos:exactMatch	mesh	D014392	Tuberculosis, Ocular	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080039	axial osteomalacia	skos:exactMatch	mesh	C537791	Axial osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080056	achondrogenesis type II	skos:exactMatch	mesh	C536017	Achondrogenesis type 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080074	neural tube defect	skos:exactMatch	mesh	D009436	Neural Tube Defects	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080091	spheroid body myopathy	skos:exactMatch	mesh	C000598645	Spheroid body myopathy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	mesh	C580012	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080187	chronic neutrophilic leukemia	skos:exactMatch	mesh	D015467	Leukemia, Neutrophilic, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080234	Clark-Baraitser syndrome	skos:exactMatch	mesh	C536208	Clark-Baraitser syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080324	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080325	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080332	bicuspid aortic valve disease	skos:exactMatch	mesh	D000082882	Bicuspid Aortic Valve Disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080344	blepharocheilodontic syndrome	skos:exactMatch	mesh	C536188	Blepharo-cheilo-dontic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080356	IgG4-related disease	skos:exactMatch	mesh	D000077733	Immunoglobulin G4-Related Disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080395	orofacial cleft 1	skos:exactMatch	mesh	C566121	Orofacial Cleft 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080396	orofacial cleft 2	skos:exactMatch	mesh	C566419	Orofacial Cleft 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080397	orofacial cleft 3	skos:exactMatch	mesh	C563448	Orofacial Cleft 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080398	orofacial cleft 4	skos:exactMatch	mesh	C564251	Orofacial Cleft 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080399	orofacial cleft 5	skos:exactMatch	mesh	C563843	Orofacial Cleft 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080402	orofacial cleft 9	skos:exactMatch	mesh	C563675	Orofacial Cleft 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080403	orofacial cleft 10	skos:exactMatch	mesh	C566605	Orofacial Cleft 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080404	orofacial cleft 11	skos:exactMatch	mesh	C567410	Orofacial Cleft 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080405	orofacial cleft 12	skos:exactMatch	mesh	C567548	Orofacial Cleft 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080494	ovarian dysgenesis 2	skos:exactMatch	mesh	C564499	Ovarian Dysgenesis 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080533	Carney-Stratakis syndrome	skos:exactMatch	mesh	C564650	Carney-Stratakis Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080539	PEHO syndrome	skos:exactMatch	mesh	C536317	PEHO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080543	hyperprolinemia type 2	skos:exactMatch	mesh	C538385	Hyperprolinemia type 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080551	Naxos disease	skos:exactMatch	mesh	C538346	Naxos disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080576	spondyloepimetaphyseal dysplasia, Genevieve-type	skos:exactMatch	mesh	C535785	Spondyloepimetaphyseal dysplasia, Genevieve type	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080580	3-Methylcrotonyl-CoA carboxylase 2 deficiency	skos:exactMatch	mesh	C535309	3-methylcrotonyl CoA carboxylase 2 deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080583	Wolfram syndrome, mitochondrial form	skos:exactMatch	mesh	C564012	Wolfram Syndrome, Mitochondrial Form	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080666	warfarin sensitivity	skos:exactMatch	mesh	C567080	Warfarin Sensitivity	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080678	mucolipidosis III gamma	skos:exactMatch	mesh	C565367	Mucolipidosis III Gamma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080695	Burn-McKeown syndrome	skos:exactMatch	mesh	C537411	Burn-Mckeown syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080696	Winchester syndrome	skos:exactMatch	mesh	C536709	Winchester syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080699	glutathione synthetase deficiency	skos:exactMatch	mesh	C536835	Glutathione synthetase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080725	BASAN syndrome	skos:exactMatch	mesh	C537659	Basan syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080741	limbic encephalitis	skos:exactMatch	mesh	D020363	Limbic Encephalitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080743	transverse myelitis	skos:exactMatch	mesh	D009188	Myelitis, Transverse	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080744	antisynthetase syndrome	skos:exactMatch	mesh	C537778	Antisynthetase syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080745	polymyositis	skos:exactMatch	mesh	D017285	Polymyositis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080746	Sweet syndrome	skos:exactMatch	mesh	D016463	Sweet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080747	chronic urticaria	skos:exactMatch	mesh	D000080223	Chronic Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080750	erythema nodosum	skos:exactMatch	mesh	D004893	Erythema Nodosum	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080768	pyridoxine-dependent epilepsy	skos:exactMatch	mesh	C536254	Pyridoxine-dependent epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080779	plasmablastic lymphoma	skos:exactMatch	mesh	D000069293	Plasmablastic Lymphoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080795	acute basophilic leukemia	skos:exactMatch	mesh	D015471	Leukemia, Basophilic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080808	mammary analogue secretory carcinoma	skos:exactMatch	mesh	D000069295	Mammary Analogue Secretory Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080820	occupational asthma	skos:exactMatch	mesh	D059366	Asthma, Occupational	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080833	laryngomalacia	skos:exactMatch	mesh	D055092	Laryngomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080912	cerebrooculofacioskeletal syndrome 2	skos:exactMatch	mesh	C565185	Cerebrooculofacioskeletal Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080913	cerebrooculofacioskeletal syndrome 3	skos:exactMatch	mesh	C565035	Cerebrooculofacioskeletal Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080914	cerebrooculofacioskeletal syndrome 4	skos:exactMatch	mesh	C565184	Cerebrooculofacioskeletal Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080918	polymicrogyria	skos:exactMatch	mesh	D065706	Polymicrogyria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080933	immunoglobulin light chain amyloidosis	skos:exactMatch	mesh	D000075363	Immunoglobulin Light-chain Amyloidosis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080940	hereditary angioedema type III	skos:exactMatch	mesh	D056828	Hereditary Angioedema Type III	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080941	acquired angioedema	skos:exactMatch	mesh	C538173	Acquired angioedema	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080942	anauxetic dysplasia	skos:exactMatch	mesh	C538256	Anauxetic dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080947	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0080990	King Denborough syndrome	skos:exactMatch	mesh	C536883	King Denborough syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081021	Tukel syndrome	skos:exactMatch	mesh	C536925	Tukel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081022	retinal cone dystrophy 3B	skos:exactMatch	mesh	C563678	Retinal Cone Dystrophy 3B	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081023	retinal cone dystrophy 4	skos:exactMatch	mesh	C566470	Retinal Cone Dystrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081024	retinal cone dystrophy 1	skos:exactMatch	mesh	C566719	Retinal Cone Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081025	retinal cone dystrophy 3A	skos:exactMatch	mesh	C566483	Retinal Cone Dystrophy 3A	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081041	B-cell prolymphocytic leukemia	skos:exactMatch	mesh	D054403	Leukemia, Prolymphocytic, B-Cell	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081042	T-cell prolymphocytic leukemia	skos:exactMatch	mesh	D015461	Leukemia, Prolymphocytic, T-Cell	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081044	frontonasal dysplasia	skos:exactMatch	mesh	C538065	Frontonasal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081057	gestational diabetes insipidus	skos:exactMatch	mesh	C548014	Gestational Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081058	dipsogenic diabetes insipidus	skos:exactMatch	mesh	C548013	Dipsogenic Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0081082	acute myelomonocytic leukemia	skos:exactMatch	mesh	D015479	Leukemia, Myelomonocytic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090002	Tietz syndrome	skos:exactMatch	mesh	C536919	Tietz syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090033	myoclonic dystonia	skos:exactMatch	mesh	C536096	Myoclonic dystonia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090048	dystonia 16	skos:exactMatch	mesh	C567430	Dystonia 16	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090056	dystonia 12	skos:exactMatch	mesh	C538001	Dystonia 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090058	torsion dystonia with onset in infancy	skos:exactMatch	mesh	C536969	Torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090066	Fanconi-like syndrome	skos:exactMatch	mesh	C536855	Fanconi like syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110006	3-methylglutaconic aciduria type 4	skos:exactMatch	mesh	C565393	3-Methylglutaconic Aciduria Type IV	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110007	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110008	achromatopsia 3	skos:exactMatch	mesh	C536129	Achromatopsia 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110010	achromatopsia 4	skos:exactMatch	mesh	C564206	Achromatopsia 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110016	Leber congenital amaurosis 2	skos:exactMatch	mesh	C536601	Amaurosis congenita of Leber, type 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110078	Leber congenital amaurosis 1	skos:exactMatch	mesh	C536600	Amaurosis congenita of Leber, type 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110080	Leber congenital amaurosis 12	skos:exactMatch	mesh	C565697	Leber Congenital Amaurosis 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110086	asphyxiating thoracic dystrophy 2	skos:exactMatch	mesh	C566982	Asphyxiating Thoracic Dystrophy 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110123	Bardet-Biedl syndrome 1	skos:exactMatch	mesh	C537909	Bardet-Biedl syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110124	Bardet-Biedl syndrome 2	skos:exactMatch	mesh	C537910	Bardet-Biedl syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110125	Bardet-Biedl syndrome 3	skos:exactMatch	mesh	C537911	Bardet-Biedl syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110126	Bardet-Biedl syndrome 4	skos:exactMatch	mesh	C537912	Bardet-Biedl syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110128	Bardet-Biedl syndrome 6	skos:exactMatch	mesh	C565738	Bardet-Biedl Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110129	Bardet-Biedl syndrome 7	skos:exactMatch	mesh	C565916	Bardet-Biedl Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110130	Bardet-Biedl syndrome 8	skos:exactMatch	mesh	C565917	Bardet-Biedl Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110131	Bardet-Biedl syndrome 9	skos:exactMatch	mesh	C565918	Bardet-Biedl Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110132	Bardet-Biedl syndrome 10	skos:exactMatch	mesh	C565919	Bardet-Biedl Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110133	Bardet-Biedl syndrome 11	skos:exactMatch	mesh	C565920	Bardet-Biedl Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110134	Bardet-Biedl syndrome 12	skos:exactMatch	mesh	C565921	Bardet-Biedl Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110135	Bardet-Biedl syndrome 13	skos:exactMatch	mesh	C567140	Bardet-Biedl Syndrome 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110136	Bardet-Biedl syndrome 14	skos:exactMatch	mesh	C567141	Bardet-Biedl Syndrome 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110188	Leber congenital amaurosis 14	skos:exactMatch	mesh	C567636	Leber Congenital Amaurosis 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110214	cleft soft palate	skos:exactMatch	mesh	C562950	Cleft Soft Palate	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0040002	aspirin allergy	skos:exactMatch	umls	C0004058	Allergy to aspirin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040004	amoxicillin allergy	skos:exactMatch	umls	C0571417	Allergy to amoxicillin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040005	ceftriaxone allergy	skos:exactMatch	umls	C0571463	Allergy to ceftriaxone	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -3460,6 +3460,7 @@ mesh	C535327	Holzgreve Wagner Rehder syndrome	skos:exactMatch	doid	DOID:0060566	
 mesh	C535328	Homocarnosinosis	skos:exactMatch	doid	DOID:0060177	homocarnosinosis	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535330	Aagenaes syndrome	skos:exactMatch	doid	DOID:6691	Aagenaes syndrome	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535334	ABCD syndrome	skos:exactMatch	doid	DOID:0050600	ABCD syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535347	Catel Manzke syndrome	skos:exactMatch	doid	0081122	Catel Manzke syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535358	Choroidal sclerosis	skos:exactMatch	doid	DOID:980	choroidal sclerosis	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535362	Chromosome 1p36 Deletion Syndrome	skos:exactMatch	doid	DOID:0060410	chromosome 1p36 deletion syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535374	Dermatopathia pigmentosa reticularis	skos:exactMatch	doid	DOID:0111342	dermatopathia pigmentosa reticularis	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3501,12 +3502,15 @@ mesh	C535557	Ablepharon macrostomia syndrome	skos:exactMatch	doid	DOID:0060550	a
 mesh	C535564	Absence of tibia with polydactyly	skos:exactMatch	doid	DOID:0111564	hypoplastic or aplastic tibia with polydactyly	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535566	Absent corpus callosum cataract immunodeficiency	skos:exactMatch	doid	DOID:0060356	Vici syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535572	Cantu syndrome	skos:exactMatch	doid	DOID:0060569	hypertrichotic osteochondrodysplasia Cantu type	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C535579	Cardiofaciocutaneous syndrome	skos:exactMatch	doid	0060233	cardiofaciocutaneous syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535581	Cardiomyopathy dilated with Woolly hair and keratoderma	skos:exactMatch	doid	DOID:0090128	Carvajal syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C535588	Carnitine palmitoyl transferase 1A deficiency	skos:exactMatch	doid	0090129	carnitine palmitoyltransferase I deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535600	dopamine beta hydroxylase deficiency	skos:exactMatch	doid	DOID:0090145	dopamine beta-hydroxylase deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535601	Dosage-sensitive sex reversal	skos:exactMatch	doid	DOID:0111777	46,XY sex reversal 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535602	Doyne honeycomb retinal dystrophy	skos:exactMatch	doid	DOID:0060745	Doyne honeycomb retinal dystrophy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535607	Aicardi-Goutieres syndrome	skos:exactMatch	doid	DOID:0050629	Aicardi-Goutieres syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535627	Hand foot uterus syndrome	skos:exactMatch	doid	DOID:0060739	hand-foot-genital syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C535642	Growth retardation, Alopecia, Pseudoanodontia and Optic atrophy	skos:exactMatch	doid	0112249	GAPO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535658	Acromesomelic dysplasia	skos:exactMatch	doid	DOID:0080049	acromesomelic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535661	Acromesomelic dysplasia, Maroteaux type	skos:exactMatch	doid	DOID:0080050	acromesomelic dysplasia, Maroteaux type	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535662	Acromicric dysplasia	skos:exactMatch	doid	DOID:0111243	acromicric dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3587,6 +3591,7 @@ mesh	C536141	Megalencephalic leukoencephalopathy with subcortical cysts	skos:exa
 mesh	C536149	Melanoma astrocytoma syndrome	skos:exactMatch	doid	DOID:0111511	melanoma and neural system tumor syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536152	Palmoplantar Keratoderma with Deafness	skos:exactMatch	doid	DOID:0111505	palmoplantar keratoderma-deafness syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536156	Keratomalacia	skos:exactMatch	doid	DOID:11267	keratomalacia	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536162	Keratosis palmoplantaris striata 1	skos:exactMatch	doid	0081108	keratosis palmoplantaris striata 1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536164	Keratosis palmoplantaris with esophageal cancer	skos:exactMatch	doid	DOID:0111506	palmoplantar keratoderma-esophageal carcinoma syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536166	Keshan disease	skos:exactMatch	doid	DOID:0050083	Keshan disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536170	Diastrophic dysplasia	skos:exactMatch	doid	DOID:14687	diastrophic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3616,6 +3621,7 @@ mesh	C536309	Patterned dystrophy of retinal pigment epithelium	skos:exactMatch	d
 mesh	C536317	PEHO syndrome	skos:exactMatch	doid	DOID:0080539	PEHO syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536321	Poikiloderma of Kindler	skos:exactMatch	doid	DOID:0060472	Kindler syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536329	Polycystic lipomembranous osteodysplasia with sclerosing leukoencephalopathy	skos:exactMatch	doid	DOID:0090112	Nasu-Hakola disease	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536330	Polycystic liver disease	skos:exactMatch	doid	0050770	polycystic liver disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536335	Polyostotic osteolytic dysplasia, hereditary expansile	skos:exactMatch	doid	DOID:0111542	familial expansile osteolysis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536352	Vitreoretinochoroidopathy	skos:exactMatch	doid	DOID:0111569	autosomal dominant vitreoretinochoroidopathy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536358	Anemia, sideroblastic spinocerebellar ataxia	skos:exactMatch	doid	DOID:0050554	X-linked sideroblastic anemia with ataxia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3712,7 +3718,9 @@ mesh	C536959	Temtamy syndrome	skos:exactMatch	doid	DOID:0111621	Temtamy syndrome
 mesh	C536962	Timothy syndrome	skos:exactMatch	doid	DOID:0060173	Timothy syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536965	Tomaculous neuropathy	skos:exactMatch	doid	DOID:0060843	hereditary neuropathy with liability to pressure palsies	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536969	Torsion dystonia with onset in infancy	skos:exactMatch	doid	DOID:0090058	torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536974	Townes-Brocks syndrome	skos:exactMatch	doid	0050887	Townes-Brocks syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536979	Transient bullous dermolysis of the newborn	skos:exactMatch	doid	DOID:0111345	transient bullous dermolysis of the newborn	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	0080688	mosaic variegated aneuploidy syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	DOID:0080141	mosaic variegated aneuploidy syndrome 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536990	Mowat-Wilson syndrome	skos:exactMatch	doid	DOID:0060485	Mowat-Wilson syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537005	Complement component 5 deficiency	skos:exactMatch	doid	DOID:8158	complement component 5 deficiency	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3768,6 +3776,7 @@ mesh	C537247	Hemochromatosis, type 2	skos:exactMatch	doid	DOID:0111034	hemochrom
 mesh	C537248	Hemochromatosis, type 3	skos:exactMatch	doid	DOID:0111030	hemochromatosis type 3	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537249	Hemochromatosis, type 4	skos:exactMatch	doid	DOID:0111028	hemochromatosis type 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537255	Hennekam lymphangiectasia lymphedema syndrome	skos:exactMatch	doid	DOID:0060366	Hennekam syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C537257	Hepatic venoocclusive disease with immunodeficiency	skos:exactMatch	doid	0112254	hepatic venoocclusive disease with immunodeficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537258	Fibrolamellar hepatocellular carcinoma	skos:exactMatch	doid	DOID:5015	fibrolamellar carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537262	Hereditary pancreatitis	skos:exactMatch	ncit	C95436	Hereditary Pancreatitis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537264	Lamellar ichthyosis, type 2	skos:exactMatch	doid	DOID:0060712	autosomal recessive congenital ichthyosis 4A	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3782,7 +3791,9 @@ mesh	C537310	Spinocerebellar ataxia, autosomal recessive 4	skos:exactMatch	doid	
 mesh	C537327	SHORT syndrome	skos:exactMatch	doid	DOID:0111454	SHORT syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537333	Siderius X-linked mental retardation syndrome	skos:exactMatch	doid	DOID:0060812	syndromic X-linked intellectual disability Siderius type	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537340	Simpson-Golabi-Behmel syndrome	skos:exactMatch	doid	DOID:0060248	Simpson-Golabi-Behmel syndrome type 1	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C537344	Sinonasal undifferentiated carcinoma	skos:exactMatch	doid	0080799	sinonasal undifferentiated carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537356	Metatropic dwarfism	skos:exactMatch	doid	DOID:0111514	metatropic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C537360	Methylmalonic aciduria cblA type	skos:exactMatch	doid	0060742	methylmalonic acidemia cblA type	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537361	Methylmalonic aciduria cblB type	skos:exactMatch	efo	0009074	methylmalonic aciduria cblb type	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537362	Immunodeficiency syndrome, variable	skos:exactMatch	doid	DOID:0090007	immunodeficiency-centromeric instability-facial anomalies syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537369	Muenke Syndrome	skos:exactMatch	doid	DOID:0060703	Muenke Syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4012,6 +4023,7 @@ mesh	C562924	Dowling-Degos Disease	skos:exactMatch	doid	DOID:0060256	Dowling-Deg
 mesh	C562938	Metachondromatosis	skos:exactMatch	doid	DOID:0111512	metachondromatosis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562943	Choroid Plexus Carcinoma	skos:exactMatch	doid	DOID:5648	choroid plexus carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562950	Cleft Soft Palate	skos:exactMatch	doid	DOID:0110214	cleft soft palate	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C562968	Spondyloepimetaphyseal Dysplasia With Joint Laxity	skos:exactMatch	doid	0112197	spondyloepimetaphyseal dysplasia with joint laxity	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563003	Pallidopontonigral Degeneration	skos:exactMatch	doid	DOID:9255	frontotemporal dementia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563008	Glycogen Storage Disease IXB	skos:exactMatch	doid	DOID:0111041	glycogen storage disease IXb	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563032	Preterm Premature Rupture of the Membranes	skos:exactMatch	doid	DOID:0111144	preterm premature rupture of the membranes	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4048,10 +4060,12 @@ mesh	C563399	Epilepsy, Myoclonic, Benign Adult Familial, Type 1	skos:exactMatch	
 mesh	C563401	Choreoathetosis-Spasticity, Episodic	skos:exactMatch	doid	DOID:0090044	dystonia 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563409	Arrhythmogenic Right Ventricular Dysplasia, Familial, 2	skos:exactMatch	doid	DOID:0110071	arrhythmogenic right ventricular dysplasia 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563410	Deafness, Autosomal Dominant 5	skos:exactMatch	doid	DOID:0110575	autosomal dominant nonsyndromic deafness 5	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C563412	Juvenile Polyposis with Hereditary Hemorrhagic Telangiectasia	skos:exactMatch	doid	0111543	juvenile polyposis-hereditary hemorrhagic telangiectasia syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563415	Cone-Rod Dystrophy 5	skos:exactMatch	doid	DOID:0111010	cone-rod dystrophy 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563417	Deafness, Autosomal Recessive 7	skos:exactMatch	doid	DOID:0110520	autosomal recessive nonsyndromic deafness 7	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563421	Deafness, Autosomal Dominant 6	skos:exactMatch	doid	DOID:0110584	autosomal dominant nonsyndromic deafness 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563423	Proprotein Convertase 1 3 Deficiency	skos:exactMatch	doid	DOID:0111698	proprotein convertase 1/3 deficiency	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C563425	Diabetes Mellitus, Permanent Neonatal	skos:exactMatch	doid	0060639	permanent neonatal diabetes mellitus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563428	Long Qt Syndrome 4	skos:exactMatch	doid	DOID:0111701	long QT syndrome 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563433	Diabetes Mellitus, Insulin-Dependent, 8	skos:exactMatch	doid	DOID:0110747	type 1 diabetes mellitus 8	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563437	Retinitis Pigmentosa 17	skos:exactMatch	doid	DOID:0110404	retinitis pigmentosa 17	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4095,6 +4109,7 @@ mesh	C563789	Peripheral Demyelinating Neuropathy, Central Dysmyelination, Waarde
 mesh	C563794	Limb-Girdle Muscular Dystrophy, Type 1G	skos:exactMatch	doid	DOID:0110306	autosomal dominant limb-girdle muscular dystrophy type 3	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563808	Arrhythmogenic Right Ventricular Dysplasia, Familial, 9	skos:exactMatch	doid	DOID:0110077	arrhythmogenic right ventricular dysplasia 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563815	Deafness, Autosomal Recessive 36	skos:exactMatch	doid	DOID:0110494	autosomal recessive nonsyndromic deafness 36	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C563822	Severe Combined Immunodeficiency, Autosomal Recessive, T Cell Negative, B Cell Positive, NK Cell Positive	skos:exactMatch	doid	0090014	severe combined immunodeficiency, autosomal recessive, T cell-negative, B cell-positive, Nk cell-positive	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563843	Orofacial Cleft 5	skos:exactMatch	doid	DOID:0080399	orofacial cleft 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563848	Alpha-B Crystallinopathy	skos:exactMatch	doid	DOID:0080093	myofibrillar myopathy 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563854	Muscular Dystrophy, Limb-Girdle, Type 2J	skos:exactMatch	doid	DOID:0110283	autosomal recessive limb-girdle muscular dystrophy type 2J	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4195,6 +4210,7 @@ mesh	C564738	Pontocerebellar Hypoplasia Type 2A	skos:exactMatch	doid	DOID:006026
 mesh	C564815	Spastic Ataxia	skos:exactMatch	doid	DOID:0050952	spastic ataxia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C564818	Peeling Skin Syndrome	skos:exactMatch	doid	DOID:0060283	peeling skin syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C564835	Enhanced S-Cone Syndrome	skos:exactMatch	doid	DOID:0090059	enhanced S-cone syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C564858	Pyruvate Kinase Deficiency of Red Cells	skos:exactMatch	doid	0111077	pyruvate kinase deficiency of red cells	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C564888	Glycogen Storage Disease of Heart, Lethal Congenital	skos:exactMatch	doid	DOID:0090101	lethal congenital glycogen storage disease of heart	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C564963	Leigh Syndrome due to Mitochondrial Complex IV Deficiency	skos:exactMatch	efo	0009135	leigh syndrome due to mitochondrial complex iv deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565070	Cleft Lip with or without Cleft Palate, Nonsyndromic, 8	skos:exactMatch	doid	DOID:0080401	orofacial cleft 8	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4234,10 +4250,12 @@ mesh	C565322	Cone-Rod Dystrophy 8	skos:exactMatch	doid	DOID:0111014	cone-rod dys
 mesh	C565325	Alzheimer Disease 6	skos:exactMatch	doid	DOID:0110038	Alzheimer's disease 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565327	Leber Congenital Amaurosis 6	skos:exactMatch	doid	DOID:0110329	Leber congenital amaurosis 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565329	Deafness, Autosomal Recessive 26	skos:exactMatch	doid	DOID:0110484	autosomal recessive nonsyndromic deafness 26	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C565342	Macrocephaly Autism Syndrome	skos:exactMatch	doid	0060867	macrocephaly-autism syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565343	Optic Atrophy 4	skos:exactMatch	doid	DOID:0111440	optic atrophy 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565353	Inflammatory Bowel Disease 7	skos:exactMatch	doid	DOID:0110882	inflammatory bowel disease 7	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565357	Deafness, Autosomal Dominant 23	skos:exactMatch	doid	DOID:0110553	autosomal dominant nonsyndromic deafness 23	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565375	Mitochondrial Complex II Deficiency	skos:exactMatch	doid	DOID:0060537	mitochondrial complex II deficiency	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C565390	Methylmalonic Aciduria due to Methylmalonyl-CoA Mutase Deficiency	skos:exactMatch	doid	0060740	methylmalonic aciduria due to methylmalonyl-CoA mutase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565393	3-Methylglutaconic Aciduria Type IV	skos:exactMatch	doid	DOID:0110006	3-methylglutaconic aciduria type 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565409	MAST Syndrome	skos:exactMatch	doid	DOID:0060245	Mast syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565452	Kniest-Like Dysplasia with Pursed Lips and Ectopia Lentis	skos:exactMatch	doid	DOID:0090005	Schwartz-Jampel syndrome 1	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4272,6 +4290,7 @@ mesh	C565778	Leber Congenital Amaurosis 4	skos:exactMatch	doid	DOID:0110332	Lebe
 mesh	C565780	Nephronophthisis 3	skos:exactMatch	doid	DOID:0111114	nephronophthisis 3	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565784	Cardioencephalomyopathy, Fatal Infantile, due to Cytochrome C Oxidase Deficiency	skos:exactMatch	doid	DOID:0050713	fatal infantile cardioencephalomyopathy due to cytochrome c oxidase deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565798	Rheumatoid Arthritis, Systemic Juvenile	skos:exactMatch	doid	DOID:676	juvenile rheumatoid arthritis	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C565808	Generalized Epilepsy with Febrile Seizures Plus	skos:exactMatch	doid	0060170	generalized epilepsy with febrile seizures plus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565809	Generalized Epilepsy With Febrile Seizures Plus, Type 1	skos:exactMatch	doid	DOID:0111302	generalized epilepsy with febrile seizures plus 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565810	Generalized Epilepsy With Febrile Seizures Plus, Type 2	skos:exactMatch	doid	DOID:0111294	generalized epilepsy with febrile seizures plus 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565814	Leber Congenital Amaurosis 3	skos:exactMatch	doid	DOID:0110331	Leber congenital amaurosis 3	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4300,6 +4319,7 @@ mesh	C565957	Amyotrophic Lateral Sclerosis 2, Juvenile	skos:exactMatch	doid	DOID
 mesh	C565974	Familial Glucocorticoid Deficiency 1	skos:exactMatch	doid	DOID:0080621	glucocorticoid deficiency 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566000	Glycoprotein IA Deficiency	skos:exactMatch	doid	DOID:0111045	platelet-type bleeding disorder 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566007	Vasculopathy, Retinal, With Cerebral Leukodystrophy	skos:exactMatch	doid	DOID:0111567	retinal vasculopathy with cerebral leukodystrophy	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C566029	Triosephosphate Isomerase Deficiency	skos:exactMatch	doid	0050884	triosephosphate isomerase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C566039	Colorectal Cancer, Hereditary Nonpolyposis, Type 6	skos:exactMatch	doid	DOID:0070273	hereditary nonpolyposis colorectal cancer type 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566044	Cardiomyopathy, Familial Hypertrophic, 9	skos:exactMatch	doid	DOID:0110315	hypertrophic cardiomyopathy 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566108	Stormorken Syndrome	skos:exactMatch	doid	DOID:0060354	Stormorken syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4372,6 +4392,7 @@ mesh	C566815	Char syndrome	skos:exactMatch	doid	DOID:0060563	Char syndrome	manua
 mesh	C566822	Perry Syndrome	skos:exactMatch	doid	DOID:0060486	Perry syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566826	Parietal Foramina	skos:exactMatch	doid	DOID:0060285	parietal foramina	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566869	Night Blindness, Congenital Stationary, Autosomal Dominant 2	skos:exactMatch	doid	DOID:0110863	congenital stationary night blindness autosomal dominant 2	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C566906	Cakut	skos:exactMatch	doid	0080205	CAKUT	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C566912	Muscular Dystrophy, Limb-Girdle, Type 2M	skos:exactMatch	doid	DOID:0110296	autosomal recessive limb-girdle muscular dystrophy type 2M	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566916	Joubert Syndrome 7	skos:exactMatch	doid	DOID:0111002	Joubert syndrome 7	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566925	Arrhythmogenic Right Ventricular Dysplasia, Familial, 12	skos:exactMatch	doid	DOID:0110083	arrhythmogenic right ventricular dysplasia 12	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4404,6 +4425,7 @@ mesh	C567084	Neuronopathy, Distal Hereditary Motor, Type IIB	skos:exactMatch	doi
 mesh	C567087	Brugada Syndrome 2	skos:exactMatch	doid	DOID:0110219	Brugada syndrome 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567090	Familial Cold Autoinflammatory Syndrome 2	skos:exactMatch	doid	DOID:0090063	familial cold autoinflammatory syndrome 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567098	Epilepsy, Familial Adult Myoclonic, 3	skos:exactMatch	doid	DOID:0111695	familial adult myoclonic epilepsy 3	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C567115	Combined Cellular And Humoral Immune Defects With Granulomas	skos:exactMatch	doid	0112253	combined cellular and humoral immune defects with granulomas	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C567125	Combined Saposin Deficiency	skos:exactMatch	doid	DOID:0111330	combined saposin deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567126	Combined Oxidative Phosphorylation Deficiency 5	skos:exactMatch	doid	DOID:0111473	combined oxidative phosphorylation deficiency 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567140	Bardet-Biedl Syndrome 13	skos:exactMatch	doid	DOID:0110135	Bardet-Biedl syndrome 13	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5047,6 +5069,7 @@ mesh	D000537	Aluminum Oxide	skos:exactMatch	chebi	CHEBI:30187	aluminium oxide	ma
 mesh	D000547	Amantadine	skos:exactMatch	chebi	CHEBI:2618	amantadine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000549	Ambenonium Chloride	skos:exactMatch	chebi	CHEBI:2628	ambenonium chloride	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D000551	Ambroxol	skos:exactMatch	chebi	CHEBI:135590	ambroxol	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D000564	Ameloblastoma	skos:exactMatch	doid	0050894	ameloblastoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000566	Amelogenesis	skos:exactMatch	go	GO:0097186	amelogenesis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000576	Americium	skos:exactMatch	chebi	CHEBI:33389	americium atom	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000583	Amikacin	skos:exactMatch	chebi	CHEBI:2637	amikacin	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5408,6 +5431,7 @@ mesh	D002748	Chlorpropham	skos:exactMatch	chebi	CHEBI:34630	chlorpropham	manuall
 mesh	D002784	Cholesterol	skos:exactMatch	chebi	CHEBI:16113	cholesterol	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002794	Choline	skos:exactMatch	chebi	CHEBI:15354	choline	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002801	Cholinesterase Reactivators	skos:exactMatch	chebi	CHEBI:50241	cholinesterase reactivator	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002805	Chondrocalcinosis	skos:exactMatch	doid	1156	chondrocalcinosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002819	Chorea	skos:exactMatch	doid	DOID:12859	choreatic disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D002821	Chorioamnionitis	skos:exactMatch	doid	DOID:0050697	chorioamnionitis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D002823	Chorion	skos:exactMatch	go	GO:0042600	chorion	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5545,6 +5569,7 @@ mesh	D005285	Fermentation	skos:exactMatch	go	GO:0006113	fermentation	manually_re
 mesh	D005306	Fertilization	skos:exactMatch	go	GO:0009566	fertilization	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005342	Fibrinolysis	skos:exactMatch	go	GO:0042730	fibrinolysis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005348	Fibrocystic Breast Disease	skos:exactMatch	doid	DOID:5998	microglandular adenosis	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D005350	Fibroma	skos:exactMatch	doid	0050871	fibroma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005355	Fibrosis	skos:exactMatch	efo	0006890	fibrosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005407	Flagella	skos:exactMatch	go	GO:0005929	cilium	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D005414	Flatulence	skos:exactMatch	efo	0009669	flatulence	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5627,6 +5652,7 @@ mesh	D006461	Hemolysis	skos:exactMatch	efo	0009473	hemolysis	manually_reviewed	o
 mesh	D006473	Postpartum Hemorrhage	skos:exactMatch	efo	0009579	postpartum hemorrhage	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006473	Postpartum Hemorrhage	skos:exactMatch	ncit	C92853	Postpartum Hemorrhage	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006487	Hemostasis	skos:exactMatch	go	GO:0007599	hemostasis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006504	Hepatic Veno-Occlusive Disease	skos:exactMatch	doid	0080177	hepatic veno-occlusive disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006550	Hernia, Femoral	skos:exactMatch	ncit	C34689	Femoral Hernia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006555	Hernia, Ventral	skos:exactMatch	ncit	C118313	Ventral Hernia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006561	Herpes Simplex	skos:exactMatch	doid	DOID:8566	herpes simplex	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5776,6 +5802,7 @@ mesh	D009336	Necrosis	skos:exactMatch	efo	0009426	necrosis	manually_reviewed	orc
 mesh	D009336	Necrosis	skos:exactMatch	go	GO:0070265	necrotic cell death	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D009369	Neoplasms	skos:exactMatch	ncit	C23988	Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D009373	Neoplasms, Germ Cell and Embryonal	skos:exactMatch	doid	DOID:688	embryonal cancer	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D009377	Multiple Endocrine Neoplasia	skos:exactMatch	doid	3125	multiple endocrine neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D009411	Nerve Endings	skos:exactMatch	go	GO:0043679	axon terminus	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D009436	Neural Tube Defects	skos:exactMatch	doid	DOID:0080074	neural tube defect	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D009456	Neurofibromatosis 1	skos:exactMatch	doid	DOID:0111253	neurofibromatosis 1	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5798,10 +5825,12 @@ mesh	D010012	Osteogenesis	skos:exactMatch	go	GO:0001503	ossification	manually_re
 mesh	D010025	Osteoradionecrosis	skos:exactMatch	ncit	C63707	Osteoradionecrosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010032	Otitis Externa	skos:exactMatch	doid	DOID:9463	otitis externa	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010040	Otosclerosis	skos:exactMatch	doid	DOID:12185	otosclerosis	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D010048	Ovarian Cysts	skos:exactMatch	doid	5119	ovarian cyst	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010058	Oviposition	skos:exactMatch	go	GO:0018991	oviposition	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010060	Ovulation	skos:exactMatch	go	GO:0030728	ovulation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010064	Embryo Implantation	skos:exactMatch	go	GO:0007566	embryo implantation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010085	Oxidative Phosphorylation	skos:exactMatch	go	GO:0006119	oxidative phosphorylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010144	Paget's Disease, Mammary	skos:exactMatch	doid	3443	mammary Paget's disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010178	Pancoast Syndrome	skos:exactMatch	doid	DOID:4876	trachea carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010182	Pancreatic Diseases	skos:exactMatch	doid	DOID:26	pancreas disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010252	Paramyxoviridae	skos:exactMatch	ncit	C14255	Paramyxoviridae	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5814,6 +5843,7 @@ mesh	D010409	Penile Diseases	skos:exactMatch	doid	DOID:1529	penile disease	manua
 mesh	D010410	Penile Erection	skos:exactMatch	go	GO:0043084	penile erection	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010427	Pentose Phosphate Pathway	skos:exactMatch	go	GO:0006098	pentose-phosphate shunt	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D010452	Peptide Biosynthesis	skos:exactMatch	go	GO:0043043	peptide biosynthetic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010523	Peripheral Nervous System Diseases	skos:exactMatch	doid	574	peripheral nervous system disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010528	Peristalsis	skos:exactMatch	go	GO:0030432	peristalsis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010554	Personality Disorders	skos:exactMatch	doid	DOID:1510	personality disorder	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010587	Phagocytosis	skos:exactMatch	go	GO:0006909	phagocytosis	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5858,6 +5888,7 @@ mesh	D011499	Protein Processing, Post-Translational	skos:exactMatch	go	GO:004368
 mesh	D011554	Pseudopodia	skos:exactMatch	go	GO:0031143	pseudopodium	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011588	Psychology, Educational	skos:exactMatch	ncit	C17030	Educational Psychology	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011618	Psychotic Disorders	skos:exactMatch	doid	DOID:2468	psychotic disorder	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D011625	Pterygium	skos:exactMatch	doid	0002116	pterygium	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011625	Pterygium	skos:exactMatch	doid	DOID:10526	conjunctival pterygium	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011654	Pulmonary Edema	skos:exactMatch	ncit	C26868	Pulmonary Edema	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011658	Pulmonary Fibrosis	skos:exactMatch	ncit	C26869	Pulmonary Fibrosis	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6157,10 +6188,12 @@ mesh	D017850	Economics, Pharmaceutical	skos:exactMatch	ncit	C142636	Pharmacoecon
 mesh	D017887	Ossification of Posterior Longitudinal Ligament	skos:exactMatch	efo	0005895	ossification of the posterior longitudinal ligament of the spine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018058	Tympanic Membrane Perforation	skos:exactMatch	efo	0009472	tympanic membrane perforation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018087	Plastids	skos:exactMatch	go	GO:0009536	plastid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018192	Lymphangioleiomyomatosis	skos:exactMatch	doid	3319	lymphangioleiomyomatosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018253	Adenoma, Villous	skos:exactMatch	doid	DOID:0050869	villous adenoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018271	Signal Recognition Particle	skos:exactMatch	go	GO:0048500	signal recognition particle	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018275	Carcinoma, Lobular	skos:exactMatch	doid	DOID:0050938	breast lobular carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018286	Carcinoma, Giant Cell	skos:exactMatch	ncit	C3779	Giant Cell Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018288	Carcinoma, Small Cell	skos:exactMatch	doid	0050685	small cell carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018293	Cystadenoma, Serous	skos:exactMatch	doid	DOID:5746	ovarian serous cystadenocarcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018295	Neoplasms, Basal Cell	skos:exactMatch	ncit	C3784	Basal Cell Neoplasm	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018308	Papilloma, Inverted	skos:exactMatch	ncit	C3793	Inverted Papilloma	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6246,6 +6279,7 @@ mesh	D020101	Acrosome Reaction	skos:exactMatch	go	GO:0007340	acrosome reaction	m
 mesh	D020160	Sodium Benzoate	skos:exactMatch	ncit	C66541	Sodium Benzoate	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D020169	Caspases	skos:exactMatch	ncit	C18153	Caspase	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D020170	Caspase 1	skos:exactMatch	hgnc	1499	CASP1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020176	Tyrosinemias	skos:exactMatch	doid	9275	tyrosinemia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D020219	Chondrogenesis	skos:exactMatch	go	GO:0051216	cartilage development	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D020237	Alexia, Pure	skos:exactMatch	doid	DOID:0060156	visual verbal agnosia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D020315	Latex Hypersensitivity	skos:exactMatch	doid	DOID:0060532	latex allergy	manually_reviewed	orcid:0000-0003-1307-2508
@@ -6397,6 +6431,7 @@ mesh	D052203	Ferrosoferric Oxide	skos:exactMatch	chebi	CHEBI:50821	ferrosoferric
 mesh	D052216	Glucagon-Like Peptide 1	skos:exactMatch	chebi	CHEBI:80270	Glucagon-like peptide 1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D052244	Endocrine Disruptors	skos:exactMatch	chebi	CHEBI:138015	endocrine disruptor	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D052578	Ionic Liquids	skos:exactMatch	chebi	CHEBI:63895	ionic liquid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D052878	Urolithiasis	skos:exactMatch	doid	0080653	urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D052998	Microcystins	skos:exactMatch	chebi	CHEBI:48041	microcystin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D053038	Quorum Sensing	skos:exactMatch	go	GO:0009372	quorum sensing	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D053119	Benzophenanthridines	skos:exactMatch	chebi	CHEBI:38518	benzophenanthridine	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2412,238 +2412,6 @@ cl	CL:0008002	skeletal muscle fiber	skos:exactMatch	mesh	D018485	Muscle Fibers, 
 cl	CL:0010003	epithelial cell of alveolus of lung	skos:exactMatch	mesh	D056809	Alveolar Epithelial Cells	manual	orcid:0000-0001-9439-5346
 cl	CL:0010017	zygote	skos:exactMatch	mesh	D015053	Zygote	manually_reviewed	orcid:0000-0001-9439-5346
 cl	CL:0010021	cardiac myoblast	skos:exactMatch	mesh	D032386	Myoblasts, Cardiac	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060046	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060259	renal-hepatic-pancreatic dysplasia	skos:exactMatch	mesh	C567142	Renal-Hepatic-Pancreatic Dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060283	peeling skin syndrome	skos:exactMatch	mesh	C564818	Peeling Skin Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060297	complement component 4a deficiency	skos:exactMatch	mesh	C565167	Complement Component 4a Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060299	complement component 6 deficiency	skos:exactMatch	mesh	C567307	Complement Component 6 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060300	complement component 7 deficiency	skos:exactMatch	mesh	C566443	Complement Component 7 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060303	complement component 9 deficiency	skos:exactMatch	mesh	C565165	C9 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060413	chromosome 22q11.2 deletion syndrome, distal	skos:exactMatch	mesh	C567511	Chromosome 22q11.2 Deletion Syndrome, Distal	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060415	chromosome 2p16.1-p15 deletion syndrome	skos:exactMatch	mesh	C567289	Chromosome 2p16.1-P15 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060416	chromosome 2q31.2 deletion syndrome	skos:exactMatch	mesh	C567344	Chromosome 2q31.2 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060422	chromosome 6pter-p24 deletion syndrome	skos:exactMatch	mesh	C567239	Chromosome 6pter-P24 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060432	chromosome 17p13.3 duplication syndrome	skos:exactMatch	mesh	C567705	Chromosome 17p13.3 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060435	chromosome 1q21.1 duplication syndrome	skos:exactMatch	mesh	C567290	Chromosome 1q21.1 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060460	chromosome 5p13 duplication syndrome	skos:exactMatch	mesh	C567717	Chromosome 5p13 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060461	chromosome Xp11.23-p11.22 duplication syndrome	skos:exactMatch	mesh	C567585	Chromosome Xp11.23-P11.22 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060540	Hermansky-Pudlak syndrome 2	skos:exactMatch	mesh	C537709	Hermansky Pudlak syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060564	spinal disease	skos:exactMatch	mesh	D013122	Spinal Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060580	Noonan syndrome 2	skos:exactMatch	mesh	C548081	Noonan Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060581	Noonan syndrome 3	skos:exactMatch	mesh	C537847	Noonan syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060582	Noonan syndrome 4	skos:exactMatch	mesh	C548082	Noonan Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060583	Noonan syndrome 5	skos:exactMatch	mesh	C548083	Noonan Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060584	Noonan syndrome 6	skos:exactMatch	mesh	C548084	Noonan Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060602	alpha-methylacyl-CoA racemase deficiency	skos:exactMatch	mesh	C565768	Alpha-Methylacyl-CoA Racemase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060604	ankyloglossia	skos:exactMatch	mesh	D000072676	Ankyloglossia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060609	microcephalic osteodysplastic primordial dwarfism type II	skos:exactMatch	mesh	C565898	Microcephalic Osteodysplastic Primordial Dwarfism, Type II	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060611	abdominal obesity-metabolic syndrome	skos:exactMatch	mesh	C535554	Abdominal obesity metabolic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060668	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060746	basal laminar drusen	skos:exactMatch	mesh	C563034	Basal Laminar Drusen	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060769	T-cell immunodeficiency, congenital alopecia, and nail dystrophy	skos:exactMatch	mesh	C536781	T-cell immunodeficiency, congenital alopecia and nail dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0060858	hypotonia-cystinuria syndrome	skos:exactMatch	mesh	C564710	Hypotonia-Cystinuria Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0070007	Seckel syndrome 1	skos:exactMatch	mesh	C537533	Seckel syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0070013	Seckel syndrome 2	skos:exactMatch	mesh	C537534	Seckel syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0070096	oculocutaneous albinism type II	skos:exactMatch	mesh	C537730	Oculocutaneous albinism type 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0070344	ocular tuberculosis	skos:exactMatch	mesh	D014392	Tuberculosis, Ocular	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080039	axial osteomalacia	skos:exactMatch	mesh	C537791	Axial osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080056	achondrogenesis type II	skos:exactMatch	mesh	C536017	Achondrogenesis type 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080074	neural tube defect	skos:exactMatch	mesh	D009436	Neural Tube Defects	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080091	spheroid body myopathy	skos:exactMatch	mesh	C000598645	Spheroid body myopathy	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	mesh	C580012	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080187	chronic neutrophilic leukemia	skos:exactMatch	mesh	D015467	Leukemia, Neutrophilic, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080234	Clark-Baraitser syndrome	skos:exactMatch	mesh	C536208	Clark-Baraitser syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080324	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080325	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080332	bicuspid aortic valve disease	skos:exactMatch	mesh	D000082882	Bicuspid Aortic Valve Disease	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080344	blepharocheilodontic syndrome	skos:exactMatch	mesh	C536188	Blepharo-cheilo-dontic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080356	IgG4-related disease	skos:exactMatch	mesh	D000077733	Immunoglobulin G4-Related Disease	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080395	orofacial cleft 1	skos:exactMatch	mesh	C566121	Orofacial Cleft 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080396	orofacial cleft 2	skos:exactMatch	mesh	C566419	Orofacial Cleft 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080397	orofacial cleft 3	skos:exactMatch	mesh	C563448	Orofacial Cleft 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080398	orofacial cleft 4	skos:exactMatch	mesh	C564251	Orofacial Cleft 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080399	orofacial cleft 5	skos:exactMatch	mesh	C563843	Orofacial Cleft 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080402	orofacial cleft 9	skos:exactMatch	mesh	C563675	Orofacial Cleft 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080403	orofacial cleft 10	skos:exactMatch	mesh	C566605	Orofacial Cleft 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080404	orofacial cleft 11	skos:exactMatch	mesh	C567410	Orofacial Cleft 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080405	orofacial cleft 12	skos:exactMatch	mesh	C567548	Orofacial Cleft 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080494	ovarian dysgenesis 2	skos:exactMatch	mesh	C564499	Ovarian Dysgenesis 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080533	Carney-Stratakis syndrome	skos:exactMatch	mesh	C564650	Carney-Stratakis Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080539	PEHO syndrome	skos:exactMatch	mesh	C536317	PEHO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080543	hyperprolinemia type 2	skos:exactMatch	mesh	C538385	Hyperprolinemia type 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080551	Naxos disease	skos:exactMatch	mesh	C538346	Naxos disease	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080576	spondyloepimetaphyseal dysplasia, Genevieve-type	skos:exactMatch	mesh	C535785	Spondyloepimetaphyseal dysplasia, Genevieve type	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080580	3-Methylcrotonyl-CoA carboxylase 2 deficiency	skos:exactMatch	mesh	C535309	3-methylcrotonyl CoA carboxylase 2 deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080583	Wolfram syndrome, mitochondrial form	skos:exactMatch	mesh	C564012	Wolfram Syndrome, Mitochondrial Form	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080666	warfarin sensitivity	skos:exactMatch	mesh	C567080	Warfarin Sensitivity	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080678	mucolipidosis III gamma	skos:exactMatch	mesh	C565367	Mucolipidosis III Gamma	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080695	Burn-McKeown syndrome	skos:exactMatch	mesh	C537411	Burn-Mckeown syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080696	Winchester syndrome	skos:exactMatch	mesh	C536709	Winchester syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080699	glutathione synthetase deficiency	skos:exactMatch	mesh	C536835	Glutathione synthetase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080725	BASAN syndrome	skos:exactMatch	mesh	C537659	Basan syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080741	limbic encephalitis	skos:exactMatch	mesh	D020363	Limbic Encephalitis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080743	transverse myelitis	skos:exactMatch	mesh	D009188	Myelitis, Transverse	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080744	antisynthetase syndrome	skos:exactMatch	mesh	C537778	Antisynthetase syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080745	polymyositis	skos:exactMatch	mesh	D017285	Polymyositis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080746	Sweet syndrome	skos:exactMatch	mesh	D016463	Sweet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080747	chronic urticaria	skos:exactMatch	mesh	D000080223	Chronic Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080750	erythema nodosum	skos:exactMatch	mesh	D004893	Erythema Nodosum	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080768	pyridoxine-dependent epilepsy	skos:exactMatch	mesh	C536254	Pyridoxine-dependent epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080779	plasmablastic lymphoma	skos:exactMatch	mesh	D000069293	Plasmablastic Lymphoma	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080795	acute basophilic leukemia	skos:exactMatch	mesh	D015471	Leukemia, Basophilic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080808	mammary analogue secretory carcinoma	skos:exactMatch	mesh	D000069295	Mammary Analogue Secretory Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080820	occupational asthma	skos:exactMatch	mesh	D059366	Asthma, Occupational	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080833	laryngomalacia	skos:exactMatch	mesh	D055092	Laryngomalacia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080912	cerebrooculofacioskeletal syndrome 2	skos:exactMatch	mesh	C565185	Cerebrooculofacioskeletal Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080913	cerebrooculofacioskeletal syndrome 3	skos:exactMatch	mesh	C565035	Cerebrooculofacioskeletal Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080914	cerebrooculofacioskeletal syndrome 4	skos:exactMatch	mesh	C565184	Cerebrooculofacioskeletal Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080918	polymicrogyria	skos:exactMatch	mesh	D065706	Polymicrogyria	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080933	immunoglobulin light chain amyloidosis	skos:exactMatch	mesh	D000075363	Immunoglobulin Light-chain Amyloidosis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080940	hereditary angioedema type III	skos:exactMatch	mesh	D056828	Hereditary Angioedema Type III	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080941	acquired angioedema	skos:exactMatch	mesh	C538173	Acquired angioedema	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080942	anauxetic dysplasia	skos:exactMatch	mesh	C538256	Anauxetic dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080947	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0080990	King Denborough syndrome	skos:exactMatch	mesh	C536883	King Denborough syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081021	Tukel syndrome	skos:exactMatch	mesh	C536925	Tukel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081022	retinal cone dystrophy 3B	skos:exactMatch	mesh	C563678	Retinal Cone Dystrophy 3B	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081023	retinal cone dystrophy 4	skos:exactMatch	mesh	C566470	Retinal Cone Dystrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081024	retinal cone dystrophy 1	skos:exactMatch	mesh	C566719	Retinal Cone Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081025	retinal cone dystrophy 3A	skos:exactMatch	mesh	C566483	Retinal Cone Dystrophy 3A	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081041	B-cell prolymphocytic leukemia	skos:exactMatch	mesh	D054403	Leukemia, Prolymphocytic, B-Cell	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081042	T-cell prolymphocytic leukemia	skos:exactMatch	mesh	D015461	Leukemia, Prolymphocytic, T-Cell	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081044	frontonasal dysplasia	skos:exactMatch	mesh	C538065	Frontonasal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081057	gestational diabetes insipidus	skos:exactMatch	mesh	C548014	Gestational Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081058	dipsogenic diabetes insipidus	skos:exactMatch	mesh	C548013	Dipsogenic Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0081082	acute myelomonocytic leukemia	skos:exactMatch	mesh	D015479	Leukemia, Myelomonocytic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090002	Tietz syndrome	skos:exactMatch	mesh	C536919	Tietz syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090033	myoclonic dystonia	skos:exactMatch	mesh	C536096	Myoclonic dystonia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090048	dystonia 16	skos:exactMatch	mesh	C567430	Dystonia 16	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090056	dystonia 12	skos:exactMatch	mesh	C538001	Dystonia 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090058	torsion dystonia with onset in infancy	skos:exactMatch	mesh	C536969	Torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090066	Fanconi-like syndrome	skos:exactMatch	mesh	C536855	Fanconi like syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0090130	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110006	3-methylglutaconic aciduria type 4	skos:exactMatch	mesh	C565393	3-Methylglutaconic Aciduria Type IV	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110007	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110008	achromatopsia 3	skos:exactMatch	mesh	C536129	Achromatopsia 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110010	achromatopsia 4	skos:exactMatch	mesh	C564206	Achromatopsia 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110016	Leber congenital amaurosis 2	skos:exactMatch	mesh	C536601	Amaurosis congenita of Leber, type 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110078	Leber congenital amaurosis 1	skos:exactMatch	mesh	C536600	Amaurosis congenita of Leber, type 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110080	Leber congenital amaurosis 12	skos:exactMatch	mesh	C565697	Leber Congenital Amaurosis 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110086	asphyxiating thoracic dystrophy 2	skos:exactMatch	mesh	C566982	Asphyxiating Thoracic Dystrophy 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110123	Bardet-Biedl syndrome 1	skos:exactMatch	mesh	C537909	Bardet-Biedl syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110124	Bardet-Biedl syndrome 2	skos:exactMatch	mesh	C537910	Bardet-Biedl syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110125	Bardet-Biedl syndrome 3	skos:exactMatch	mesh	C537911	Bardet-Biedl syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110126	Bardet-Biedl syndrome 4	skos:exactMatch	mesh	C537912	Bardet-Biedl syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110128	Bardet-Biedl syndrome 6	skos:exactMatch	mesh	C565738	Bardet-Biedl Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110129	Bardet-Biedl syndrome 7	skos:exactMatch	mesh	C565916	Bardet-Biedl Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110130	Bardet-Biedl syndrome 8	skos:exactMatch	mesh	C565917	Bardet-Biedl Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110131	Bardet-Biedl syndrome 9	skos:exactMatch	mesh	C565918	Bardet-Biedl Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110132	Bardet-Biedl syndrome 10	skos:exactMatch	mesh	C565919	Bardet-Biedl Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110133	Bardet-Biedl syndrome 11	skos:exactMatch	mesh	C565920	Bardet-Biedl Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110134	Bardet-Biedl syndrome 12	skos:exactMatch	mesh	C565921	Bardet-Biedl Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110135	Bardet-Biedl syndrome 13	skos:exactMatch	mesh	C567140	Bardet-Biedl Syndrome 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110136	Bardet-Biedl syndrome 14	skos:exactMatch	mesh	C567141	Bardet-Biedl Syndrome 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110188	Leber congenital amaurosis 14	skos:exactMatch	mesh	C567636	Leber Congenital Amaurosis 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110214	cleft soft palate	skos:exactMatch	mesh	C562950	Cleft Soft Palate	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110215	Leber congenital amaurosis 5	skos:exactMatch	mesh	C536602	Amaurosis congenita of Leber, type 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110216	Leber congenital amaurosis 11	skos:exactMatch	mesh	C564140	Leber Congenital Amaurosis 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110219	Brugada syndrome 2	skos:exactMatch	mesh	C567087	Brugada Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110220	Brugada syndrome 3	skos:exactMatch	mesh	C567509	Brugada Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110221	Brugada syndrome 4	skos:exactMatch	mesh	C567508	Brugada Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110222	Brugada syndrome 5	skos:exactMatch	mesh	C567556	Brugada Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110223	Brugada syndrome 6	skos:exactMatch	mesh	C567735	Brugada Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110224	Brugada syndrome 7	skos:exactMatch	mesh	C567734	Brugada Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110225	Brugada syndrome 8	skos:exactMatch	mesh	C567732	Brugada Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110291	Leber congenital amaurosis 10	skos:exactMatch	mesh	C565720	Leber Congenital Amaurosis 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110329	Leber congenital amaurosis 6	skos:exactMatch	mesh	C565327	Leber Congenital Amaurosis 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110330	Leber congenital amaurosis 13	skos:exactMatch	mesh	C567197	Leber Congenital Amaurosis 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110331	Leber congenital amaurosis 3	skos:exactMatch	mesh	C565814	Leber Congenital Amaurosis 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110332	Leber congenital amaurosis 4	skos:exactMatch	mesh	C565778	Leber Congenital Amaurosis 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110337	osteogenesis imperfecta type 7	skos:exactMatch	mesh	C565200	Osteogenesis Imperfecta Type VII	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110353	retinitis pigmentosa 20	skos:exactMatch	mesh	C566718	Retinitis Pigmentosa 20	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110354	retinitis pigmentosa 19	skos:exactMatch	mesh	C566637	Retinitis Pigmentosa 19	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110355	retinitis pigmentosa 32	skos:exactMatch	mesh	C563689	Retinitis Pigmentosa 32	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110356	retinitis pigmentosa 18	skos:exactMatch	mesh	C563320	Retinitis Pigmentosa 18	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110357	retinitis pigmentosa 35	skos:exactMatch	mesh	C565206	Retinitis Pigmentosa 35	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110358	retinitis pigmentosa 12	skos:exactMatch	mesh	C563999	Retinitis Pigmentosa 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110366	retinitis pigmentosa 33	skos:exactMatch	mesh	C563676	Retinitis Pigmentosa 33	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110368	retinitis pigmentosa 26	skos:exactMatch	mesh	C564249	Retinitis Pigmentosa 26	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110376	retinitis pigmentosa 41	skos:exactMatch	mesh	C567422	Retinitis Pigmentosa 41	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110378	retinitis pigmentosa 29	skos:exactMatch	mesh	C567403	Retinitis Pigmentosa 29	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110381	retinitis pigmentosa 14	skos:exactMatch	mesh	C563992	Retinitis Pigmentosa 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110383	retinitis pigmentosa 7	skos:exactMatch	mesh	C564284	Retinitis Pigmentosa 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110384	retinitis pigmentosa 25	skos:exactMatch	mesh	C566425	Retinitis Pigmentosa 25	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110386	retinitis pigmentosa 42	skos:exactMatch	mesh	C567854	Retinitis Pigmentosa 42	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110387	retinitis pigmentosa 9	skos:exactMatch	mesh	C566716	Retinitis Pigmentosa 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110388	retinitis pigmentosa 10	skos:exactMatch	mesh	C566715	Retinitis Pigmentosa 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110391	retinitis pigmentosa 31	skos:exactMatch	mesh	C563685	Retinitis Pigmentosa 31	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110397	retinitis pigmentosa 27	skos:exactMatch	mesh	C563526	Retinitis Pigmentosa 27	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110399	retinitis pigmentosa 37	skos:exactMatch	mesh	C567005	Retinitis Pigmentosa 37	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110403	retinitis pigmentosa 13	skos:exactMatch	mesh	C564008	Retinitis Pigmentosa 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110404	retinitis pigmentosa 17	skos:exactMatch	mesh	C563437	Retinitis Pigmentosa 17	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110405	retinitis pigmentosa 36	skos:exactMatch	mesh	C566431	Retinitis Pigmentosa 36	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110406	retinitis pigmentosa 30	skos:exactMatch	mesh	C564310	Retinitis Pigmentosa 30	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110408	retinitis pigmentosa 11	skos:exactMatch	mesh	C563991	Retinitis Pigmentosa 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110409	retinitis pigmentosa 46	skos:exactMatch	mesh	C567249	Retinitis Pigmentosa 46	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110413	retinitis pigmentosa 6	skos:exactMatch	mesh	C564065	Retinitis Pigmentosa 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110414	retinitis pigmentosa 3	skos:exactMatch	mesh	C564520	Retinitis Pigmentosa 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110415	retinitis pigmentosa 2	skos:exactMatch	mesh	C567523	Retinitis Pigmentosa 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110417	retinitis pigmentosa 34	skos:exactMatch	mesh	C564475	Retinitis Pigmentosa 34	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110630	Wolfram syndrome 2	skos:exactMatch	mesh	C565733	Wolfram Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110645	long QT syndrome 2	skos:exactMatch	mesh	C563614	Long Qt Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110646	long QT syndrome 3	skos:exactMatch	mesh	C565840	Long Qt Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110647	long QT syndrome 5	skos:exactMatch	mesh	C566766	Long Qt Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110648	long QT syndrome 6	skos:exactMatch	mesh	C566333	Long Qt Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110650	long QT syndrome 9	skos:exactMatch	mesh	C567515	Long Qt Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110651	long QT syndrome 10	skos:exactMatch	mesh	C567514	Long Qt Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110652	long QT syndrome 11	skos:exactMatch	mesh	C567513	Long Qt Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110653	long QT syndrome 12	skos:exactMatch	mesh	C567842	Long Qt Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110702	hypotrichosis 5	skos:exactMatch	mesh	C567554	Hypotrichosis 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110736	neurodegeneration with brain iron accumulation 2b	skos:exactMatch	mesh	C565699	NBIA2B	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110872	holoprosencephaly 2	skos:exactMatch	mesh	C563579	Holoprosencephaly 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110873	holoprosencephaly 9	skos:exactMatch	mesh	C563659	Holoprosencephaly 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110874	holoprosencephaly 6	skos:exactMatch	mesh	C565274	Holoprosencephaly 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110875	holoprosencephaly 3	skos:exactMatch	mesh	C564181	Holoprosencephaly 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110876	holoprosencephaly 7	skos:exactMatch	mesh	C563660	Holoprosencephaly 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110878	holoprosencephaly 5	skos:exactMatch	mesh	C566464	Holoprosencephaly 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110879	holoprosencephaly 8	skos:exactMatch	mesh	C563723	Holoprosencephaly 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110880	holoprosencephaly 4	skos:exactMatch	mesh	C564180	Holoprosencephaly 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110882	inflammatory bowel disease 7	skos:exactMatch	mesh	C565353	Inflammatory Bowel Disease 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110883	inflammatory bowel disease 17	skos:exactMatch	mesh	C567378	Inflammatory Bowel Disease 17	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110884	inflammatory bowel disease 23	skos:exactMatch	mesh	C567326	Inflammatory Bowel Disease 23	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110885	inflammatory bowel disease 10	skos:exactMatch	mesh	C567021	Inflammatory Bowel Disease 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110886	inflammatory bowel disease 9	skos:exactMatch	mesh	C563926	Inflammatory Bowel Disease 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110887	inflammatory bowel disease 12	skos:exactMatch	mesh	C567388	Inflammatory Bowel Disease 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110888	inflammatory bowel disease 18	skos:exactMatch	mesh	C567377	Inflammatory Bowel Disease 18	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110889	inflammatory bowel disease 5	skos:exactMatch	mesh	C565234	Inflammatory Bowel Disease 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110890	inflammatory bowel disease 19	skos:exactMatch	mesh	C567372	Inflammatory Bowel Disease 19	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110891	inflammatory bowel disease 3	skos:exactMatch	mesh	C565764	Inflammatory Bowel Disease 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110893	inflammatory bowel disease 13	skos:exactMatch	mesh	C567384	Inflammatory Bowel Disease 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110894	inflammatory bowel disease 11	skos:exactMatch	mesh	C567154	Inflammatory Bowel Disease 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110895	inflammatory bowel disease 14	skos:exactMatch	mesh	C567383	Inflammatory Bowel Disease 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110896	inflammatory bowel disease 16	skos:exactMatch	mesh	C567380	Inflammatory Bowel Disease 16	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110897	inflammatory bowel disease 15	skos:exactMatch	mesh	C567381	Inflammatory Bowel Disease 15	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110898	inflammatory bowel disease 20	skos:exactMatch	mesh	C567361	Inflammatory Bowel Disease 20	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110900	inflammatory bowel disease 2	skos:exactMatch	mesh	C563310	Inflammatory Bowel Disease 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110901	inflammatory bowel disease 26	skos:exactMatch	mesh	C567217	Inflammatory Bowel Disease 26	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110902	inflammatory bowel disease 27	skos:exactMatch	mesh	C567559	Inflammatory Bowel Disease 27	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110903	inflammatory bowel disease 4	skos:exactMatch	mesh	C564680	Inflammatory Bowel Disease 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110904	inflammatory bowel disease 8	skos:exactMatch	mesh	C564682	Inflammatory Bowel Disease 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110905	inflammatory bowel disease 22	skos:exactMatch	mesh	C567327	Inflammatory Bowel Disease 22	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110906	inflammatory bowel disease 21	skos:exactMatch	mesh	C567338	Inflammatory Bowel Disease 21	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110907	inflammatory bowel disease 6	skos:exactMatch	mesh	C564681	Inflammatory Bowel Disease 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110908	inflammatory bowel disease 24	skos:exactMatch	mesh	C567252	Inflammatory Bowel Disease 24	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110912	leukocyte adhesion deficiency 3	skos:exactMatch	mesh	C567555	Leukocyte Adhesion Deficiency, Type III	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110926	nemaline myopathy 1	skos:exactMatch	mesh	C538348	Nemaline myopathy 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110928	nemaline myopathy 2	skos:exactMatch	mesh	C538349	Nemaline Myopathy 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110932	nemaline myopathy 4	skos:exactMatch	mesh	C538351	Nemaline myopathy 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110934	nemaline myopathy 7	skos:exactMatch	mesh	C565198	Nemaline Myopathy 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110935	nemaline myopathy 6	skos:exactMatch	mesh	C538398	Nemaline myopathy 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110936	nemaline myopathy 5	skos:exactMatch	mesh	C538397	Nemaline myopathy 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110947	Waardenburg syndrome type 2B	skos:exactMatch	mesh	C536465	Waardenburg syndrome type 2B	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110950	Waardenburg syndrome type 2A	skos:exactMatch	mesh	C536464	Waardenburg syndrome type 2A	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110964	brachydactyly type A1	skos:exactMatch	mesh	C537088	Brachydactyly type A1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	0110966	brachydactyly type A3	skos:exactMatch	mesh	C537090	Brachydactyly type A3	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0040002	aspirin allergy	skos:exactMatch	umls	C0004058	Allergy to aspirin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040004	amoxicillin allergy	skos:exactMatch	umls	C0571417	Allergy to amoxicillin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040005	ceftriaxone allergy	skos:exactMatch	umls	C0571463	Allergy to ceftriaxone	manually_reviewed	orcid:0000-0003-4423-4370
@@ -2745,44 +2513,122 @@ doid	DOID:0050855	renal fibrosis	skos:exactMatch	umls	C0151650	Renal fibrosis	ma
 doid	DOID:0050933	ovarian serous carcinoma	skos:exactMatch	efo	1001516	ovarian serous carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050985	spinocerebellar ataxia type 38	skos:exactMatch	efo	0009056	Spinocerebellar ataxia type 38	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050986	spinocerebellar ataxia type 40	skos:exactMatch	efo	0009057	Spinocerebellar ataxia type 40	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060046	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060077	progesterone-receptor positive breast cancer	skos:exactMatch	efo	0009782	progesterone-receptor positive breast cancer	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060098	osteoblastoma	skos:exactMatch	efo	1000410	Osteoblastoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060259	renal-hepatic-pancreatic dysplasia	skos:exactMatch	mesh	C567142	Renal-Hepatic-Pancreatic Dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060283	peeling skin syndrome	skos:exactMatch	mesh	C564818	Peeling Skin Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060297	complement component 4a deficiency	skos:exactMatch	mesh	C565167	Complement Component 4a Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060299	complement component 6 deficiency	skos:exactMatch	mesh	C567307	Complement Component 6 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060300	complement component 7 deficiency	skos:exactMatch	mesh	C566443	Complement Component 7 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060303	complement component 9 deficiency	skos:exactMatch	mesh	C565165	C9 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060317	lung abscess	skos:exactMatch	mesh	D008169	Lung Abscess	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0060317	lung abscess	skos:exactMatch	umls	C0024110	Lung Abscess	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0060319	cardiac arrest	skos:exactMatch	efo	0009492	cardiac arrest	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060325	cervical polyp	skos:exactMatch	efo	0009475	cervical polyp	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060413	chromosome 22q11.2 deletion syndrome, distal	skos:exactMatch	mesh	C567511	Chromosome 22q11.2 Deletion Syndrome, Distal	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060415	chromosome 2p16.1-p15 deletion syndrome	skos:exactMatch	mesh	C567289	Chromosome 2p16.1-P15 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060416	chromosome 2q31.2 deletion syndrome	skos:exactMatch	mesh	C567344	Chromosome 2q31.2 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060422	chromosome 6pter-p24 deletion syndrome	skos:exactMatch	mesh	C567239	Chromosome 6pter-P24 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060432	chromosome 17p13.3 duplication syndrome	skos:exactMatch	mesh	C567705	Chromosome 17p13.3 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060435	chromosome 1q21.1 duplication syndrome	skos:exactMatch	mesh	C567290	Chromosome 1q21.1 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060460	chromosome 5p13 duplication syndrome	skos:exactMatch	mesh	C567717	Chromosome 5p13 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060461	chromosome Xp11.23-p11.22 duplication syndrome	skos:exactMatch	mesh	C567585	Chromosome Xp11.23-P11.22 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060538	purpura fulminans	skos:exactMatch	efo	1001913	Purpura Fulminans	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060540	Hermansky-Pudlak syndrome 2	skos:exactMatch	mesh	C537709	Hermansky Pudlak syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060564	spinal disease	skos:exactMatch	mesh	D013122	Spinal Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060580	Noonan syndrome 2	skos:exactMatch	mesh	C548081	Noonan Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060581	Noonan syndrome 3	skos:exactMatch	mesh	C537847	Noonan syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060582	Noonan syndrome 4	skos:exactMatch	mesh	C548082	Noonan Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060583	Noonan syndrome 5	skos:exactMatch	mesh	C548083	Noonan Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060584	Noonan syndrome 6	skos:exactMatch	mesh	C548084	Noonan Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060602	alpha-methylacyl-CoA racemase deficiency	skos:exactMatch	mesh	C565768	Alpha-Methylacyl-CoA Racemase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060604	ankyloglossia	skos:exactMatch	mesh	D000072676	Ankyloglossia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060609	microcephalic osteodysplastic primordial dwarfism type II	skos:exactMatch	mesh	C565898	Microcephalic Osteodysplastic Primordial Dwarfism, Type II	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060611	abdominal obesity-metabolic syndrome	skos:exactMatch	mesh	C535554	Abdominal obesity metabolic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060611	abdominal obesity-metabolic syndrome	skos:exactMatch	umls	C2930930	Abdominal obesity metabolic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060612	abdominal obesity-metabolic syndrome 3	skos:exactMatch	umls	C4014361	ABDOMINAL OBESITY-METABOLIC SYNDROME 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060668	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060743	methylmalonic acidemia cblB type	skos:exactMatch	mesh	C537361	Methylmalonic aciduria cblB type	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060743	methylmalonic acidemia cblB type	skos:exactMatch	umls	C1855102	Methylmalonic aciduria cblB type	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060746	basal laminar drusen	skos:exactMatch	mesh	C563034	Basal Laminar Drusen	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060769	T-cell immunodeficiency, congenital alopecia, and nail dystrophy	skos:exactMatch	mesh	C536781	T-cell immunodeficiency, congenital alopecia and nail dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0060858	hypotonia-cystinuria syndrome	skos:exactMatch	mesh	C564710	Hypotonia-Cystinuria Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060887	ossification of the posterior longitudinal ligament of spine	skos:exactMatch	mesh	C537143	Ossification of the posterior longitudinal ligament of the spine	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060887	ossification of the posterior longitudinal ligament of spine	skos:exactMatch	umls	C1865343	OSSIFICATION OF THE POSTERIOR LONGITUDINAL LIGAMENT OF SPINE	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070007	Seckel syndrome 1	skos:exactMatch	mesh	C537533	Seckel syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070013	Seckel syndrome 2	skos:exactMatch	mesh	C537534	Seckel syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070096	oculocutaneous albinism type II	skos:exactMatch	mesh	C537730	Oculocutaneous albinism type 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070227	intrahepatic cholestasis of pregnancy	skos:exactMatch	efo	0009048	Intrahepatic cholestasis of pregnancy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070296	primary autosomal recessive microcephaly	skos:exactMatch	mesh	C579935	Autosomal Recessive Primary Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070306	post-cardiac arrest syndrome	skos:exactMatch	mesh	D000080942	Post-Cardiac Arrest Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070323	childhood acute myeloid leukemia	skos:exactMatch	efo	0000330	childhood acute myeloid leukemia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070344	ocular tuberculosis	skos:exactMatch	mesh	D014392	Tuberculosis, Ocular	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070346	neurodevelopmental disorder with cataracts, poor growth, and dysmorphic facies	skos:exactMatch	efo	0010561	neurodevelopmental disorder with cataracts, poor growth, and dysmorphic facies	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080039	axial osteomalacia	skos:exactMatch	mesh	C537791	Axial osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080043	achondrogenesis	skos:exactMatch	mesh	C579878	Achondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080056	achondrogenesis type II	skos:exactMatch	mesh	C536017	Achondrogenesis type 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080074	neural tube defect	skos:exactMatch	mesh	D009436	Neural Tube Defects	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080091	spheroid body myopathy	skos:exactMatch	mesh	C000598645	Spheroid body myopathy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	mesh	C580012	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	umls	C1302995	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080178	mucositis	skos:exactMatch	efo	1001898	mucositis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080187	chronic neutrophilic leukemia	skos:exactMatch	mesh	D015467	Leukemia, Neutrophilic, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080234	Clark-Baraitser syndrome	skos:exactMatch	mesh	C536208	Clark-Baraitser syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080322	polycystic kidney disease	skos:exactMatch	efo	0008620	Polycystic Kidney Disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080324	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080325	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080332	bicuspid aortic valve disease	skos:exactMatch	mesh	D000082882	Bicuspid Aortic Valve Disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080344	blepharocheilodontic syndrome	skos:exactMatch	mesh	C536188	Blepharo-cheilo-dontic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080356	IgG4-related disease	skos:exactMatch	mesh	D000077733	Immunoglobulin G4-Related Disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080395	orofacial cleft 1	skos:exactMatch	mesh	C566121	Orofacial Cleft 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080396	orofacial cleft 2	skos:exactMatch	mesh	C566419	Orofacial Cleft 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080397	orofacial cleft 3	skos:exactMatch	mesh	C563448	Orofacial Cleft 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080398	orofacial cleft 4	skos:exactMatch	mesh	C564251	Orofacial Cleft 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080399	orofacial cleft 5	skos:exactMatch	mesh	C563843	Orofacial Cleft 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080402	orofacial cleft 9	skos:exactMatch	mesh	C563675	Orofacial Cleft 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080403	orofacial cleft 10	skos:exactMatch	mesh	C566605	Orofacial Cleft 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080404	orofacial cleft 11	skos:exactMatch	mesh	C567410	Orofacial Cleft 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080405	orofacial cleft 12	skos:exactMatch	mesh	C567548	Orofacial Cleft 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080494	ovarian dysgenesis 2	skos:exactMatch	mesh	C564499	Ovarian Dysgenesis 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080531	dedifferentiated liposarcoma	skos:exactMatch	efo	0003085	dedifferentiated liposarcoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080533	Carney-Stratakis syndrome	skos:exactMatch	mesh	C564650	Carney-Stratakis Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080539	PEHO syndrome	skos:exactMatch	mesh	C536317	PEHO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080543	hyperprolinemia type 2	skos:exactMatch	mesh	C538385	Hyperprolinemia type 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080546	non-alcoholic fatty liver	skos:exactMatch	efo	1001248	non-alcoholic fatty liver	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080547	non-alcoholic steatohepatitis	skos:exactMatch	efo	1001249	non-alcoholic steatohepatitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080551	Naxos disease	skos:exactMatch	mesh	C538346	Naxos disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080576	spondyloepimetaphyseal dysplasia, Genevieve-type	skos:exactMatch	mesh	C535785	Spondyloepimetaphyseal dysplasia, Genevieve type	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080580	3-Methylcrotonyl-CoA carboxylase 2 deficiency	skos:exactMatch	mesh	C535309	3-methylcrotonyl CoA carboxylase 2 deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080583	Wolfram syndrome, mitochondrial form	skos:exactMatch	mesh	C564012	Wolfram Syndrome, Mitochondrial Form	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080666	warfarin sensitivity	skos:exactMatch	mesh	C567080	Warfarin Sensitivity	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080678	mucolipidosis III gamma	skos:exactMatch	mesh	C565367	Mucolipidosis III Gamma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080690	RASopathy	skos:exactMatch	efo	1001502	rasopathy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080695	Burn-McKeown syndrome	skos:exactMatch	mesh	C537411	Burn-Mckeown syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080696	Winchester syndrome	skos:exactMatch	mesh	C536709	Winchester syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080699	glutathione synthetase deficiency	skos:exactMatch	mesh	C536835	Glutathione synthetase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080711	multisystem inflammatory syndrome in children	skos:exactMatch	mesh	C000705967	pediatric multisystem inflammatory disease, COVID-19 related	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080725	BASAN syndrome	skos:exactMatch	mesh	C537659	Basan syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080741	limbic encephalitis	skos:exactMatch	mesh	D020363	Limbic Encephalitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080743	transverse myelitis	skos:exactMatch	mesh	D009188	Myelitis, Transverse	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080744	antisynthetase syndrome	skos:exactMatch	efo	1001982	Antisynthetase syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080744	antisynthetase syndrome	skos:exactMatch	mesh	C537778	Antisynthetase syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080745	polymyositis	skos:exactMatch	efo	0003063	polymyositis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080745	polymyositis	skos:exactMatch	mesh	D017285	Polymyositis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080746	Sweet syndrome	skos:exactMatch	mesh	D016463	Sweet Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080747	chronic urticaria	skos:exactMatch	mesh	D000080223	Chronic Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080750	erythema nodosum	skos:exactMatch	mesh	D004893	Erythema Nodosum	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080768	pyridoxine-dependent epilepsy	skos:exactMatch	mesh	C536254	Pyridoxine-dependent epilepsy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080777	lung sarcomatoid carcinoma	skos:exactMatch	efo	1000336	Lung Sarcomatoid Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080779	plasmablastic lymphoma	skos:exactMatch	mesh	D000069293	Plasmablastic Lymphoma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080780	acute erythroid leukemia	skos:exactMatch	efo	0000218	acute erythroleukemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080784	urinary tract infection	skos:exactMatch	efo	0003103	urinary tract infection	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080794	childhood acute megakaryoblastic leukemia	skos:exactMatch	efo	1001943	childhood acute megakaryoblastic leukemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080795	acute basophilic leukemia	skos:exactMatch	efo	0003029	acute basophilic leukemia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080795	acute basophilic leukemia	skos:exactMatch	mesh	D015471	Leukemia, Basophilic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080796	core binding factor acute myeloid leukemia	skos:exactMatch	efo	1002001	core binding factor acute myeloid leukemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080799	sinonasal undifferentiated carcinoma	skos:exactMatch	efo	1000527	Sinonasal Undifferentiated Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080808	mammary analogue secretory carcinoma	skos:exactMatch	mesh	D000069295	Mammary Analogue Secretory Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080815	childhood-onset asthma	skos:exactMatch	efo	0004591	childhood onset asthma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080820	occupational asthma	skos:exactMatch	mesh	D059366	Asthma, Occupational	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080833	laryngomalacia	skos:exactMatch	mesh	D055092	Laryngomalacia	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2795,40 +2641,276 @@ doid	DOID:0080851	IgA pemphigus	skos:exactMatch	efo	0008604	IgA pemphigus	manual
 doid	DOID:0080852	paraneoplastic pemphigus	skos:exactMatch	efo	0008602	paraneoplastic pemphigus	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080898	cerebellofaciodental syndrome	skos:exactMatch	efo	0009030	Cerebellar-facial-dental syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080899	lung pleomorphic carcinoma	skos:exactMatch	umls	C1711397	Lung Pleomorphic Carcinoma	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:0080912	cerebrooculofacioskeletal syndrome 2	skos:exactMatch	mesh	C565185	Cerebrooculofacioskeletal Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080913	cerebrooculofacioskeletal syndrome 3	skos:exactMatch	mesh	C565035	Cerebrooculofacioskeletal Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080914	cerebrooculofacioskeletal syndrome 4	skos:exactMatch	mesh	C565184	Cerebrooculofacioskeletal Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080918	polymicrogyria	skos:exactMatch	mesh	D065706	Polymicrogyria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080933	immunoglobulin light chain amyloidosis	skos:exactMatch	mesh	D000075363	Immunoglobulin Light-chain Amyloidosis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080940	hereditary angioedema type III	skos:exactMatch	mesh	D056828	Hereditary Angioedema Type III	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080941	acquired angioedema	skos:exactMatch	mesh	C538173	Acquired angioedema	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080942	anauxetic dysplasia	skos:exactMatch	mesh	C538256	Anauxetic dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080947	acute flaccid myelitis	skos:exactMatch	mesh	C000629404	acute flaccid myelitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080990	King Denborough syndrome	skos:exactMatch	mesh	C536883	King Denborough syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081021	Tukel syndrome	skos:exactMatch	mesh	C536925	Tukel syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081022	retinal cone dystrophy 3B	skos:exactMatch	mesh	C563678	Retinal Cone Dystrophy 3B	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081023	retinal cone dystrophy 4	skos:exactMatch	mesh	C566470	Retinal Cone Dystrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081024	retinal cone dystrophy 1	skos:exactMatch	mesh	C566719	Retinal Cone Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081025	retinal cone dystrophy 3A	skos:exactMatch	mesh	C566483	Retinal Cone Dystrophy 3A	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081041	B-cell prolymphocytic leukemia	skos:exactMatch	mesh	D054403	Leukemia, Prolymphocytic, B-Cell	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081042	T-cell prolymphocytic leukemia	skos:exactMatch	mesh	D015461	Leukemia, Prolymphocytic, T-Cell	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081044	frontonasal dysplasia	skos:exactMatch	mesh	C538065	Frontonasal dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081057	gestational diabetes insipidus	skos:exactMatch	mesh	C548014	Gestational Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081058	dipsogenic diabetes insipidus	skos:exactMatch	mesh	C548013	Dipsogenic Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0081082	acute myelomonocytic leukemia	skos:exactMatch	mesh	D015479	Leukemia, Myelomonocytic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090002	Tietz syndrome	skos:exactMatch	mesh	C536919	Tietz syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090033	myoclonic dystonia	skos:exactMatch	mesh	C536096	Myoclonic dystonia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090048	dystonia 16	skos:exactMatch	mesh	C567430	Dystonia 16	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090056	dystonia 12	skos:exactMatch	mesh	C538001	Dystonia 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090058	torsion dystonia with onset in infancy	skos:exactMatch	mesh	C536969	Torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090066	Fanconi-like syndrome	skos:exactMatch	mesh	C536855	Fanconi like syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0090113	RIDDLE syndrome	skos:exactMatch	efo	0009055	RIDDLE syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0090130	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110006	3-methylglutaconic aciduria type 4	skos:exactMatch	mesh	C565393	3-Methylglutaconic Aciduria Type IV	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110007	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110008	achromatopsia 3	skos:exactMatch	mesh	C536129	Achromatopsia 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110010	achromatopsia 4	skos:exactMatch	mesh	C564206	Achromatopsia 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110016	Leber congenital amaurosis 2	skos:exactMatch	mesh	C536601	Amaurosis congenita of Leber, type 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110078	Leber congenital amaurosis 1	skos:exactMatch	mesh	C536600	Amaurosis congenita of Leber, type 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110080	Leber congenital amaurosis 12	skos:exactMatch	mesh	C565697	Leber Congenital Amaurosis 12	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110085	asphyxiating thoracic dystrophy 1	skos:exactMatch	umls	C4551856	Asphyxiating Thoracic Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110086	asphyxiating thoracic dystrophy 2	skos:exactMatch	mesh	C566982	Asphyxiating Thoracic Dystrophy 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110086	asphyxiating thoracic dystrophy 2	skos:exactMatch	umls	C1970005	Asphyxiating Thoracic Dystrophy 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110123	Bardet-Biedl syndrome 1	skos:exactMatch	efo	0009021	Bardet-Biedl syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110123	Bardet-Biedl syndrome 1	skos:exactMatch	mesh	C537909	Bardet-Biedl syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110124	Bardet-Biedl syndrome 2	skos:exactMatch	mesh	C537910	Bardet-Biedl syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110125	Bardet-Biedl syndrome 3	skos:exactMatch	mesh	C537911	Bardet-Biedl syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110126	Bardet-Biedl syndrome 4	skos:exactMatch	efo	0009024	Bardet-Biedl syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110126	Bardet-Biedl syndrome 4	skos:exactMatch	mesh	C537912	Bardet-Biedl syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110127	Bardet-Biedl syndrome 5	skos:exactMatch	efo	0009025	Bardet-Biedl syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110128	Bardet-Biedl syndrome 6	skos:exactMatch	mesh	C565738	Bardet-Biedl Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110129	Bardet-Biedl syndrome 7	skos:exactMatch	efo	0009026	Bardet-Biedl syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110129	Bardet-Biedl syndrome 7	skos:exactMatch	mesh	C565916	Bardet-Biedl Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110130	Bardet-Biedl syndrome 8	skos:exactMatch	mesh	C565917	Bardet-Biedl Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110131	Bardet-Biedl syndrome 9	skos:exactMatch	efo	0009027	Bardet-Biedl syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110131	Bardet-Biedl syndrome 9	skos:exactMatch	mesh	C565918	Bardet-Biedl Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110132	Bardet-Biedl syndrome 10	skos:exactMatch	efo	0009022	Bardet-Biedl syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110132	Bardet-Biedl syndrome 10	skos:exactMatch	mesh	C565919	Bardet-Biedl Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110133	Bardet-Biedl syndrome 11	skos:exactMatch	mesh	C565920	Bardet-Biedl Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110134	Bardet-Biedl syndrome 12	skos:exactMatch	efo	0009023	Bardet-Biedl syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110134	Bardet-Biedl syndrome 12	skos:exactMatch	mesh	C565921	Bardet-Biedl Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110135	Bardet-Biedl syndrome 13	skos:exactMatch	mesh	C567140	Bardet-Biedl Syndrome 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110136	Bardet-Biedl syndrome 14	skos:exactMatch	mesh	C567141	Bardet-Biedl Syndrome 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110188	Leber congenital amaurosis 14	skos:exactMatch	mesh	C567636	Leber Congenital Amaurosis 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110214	cleft soft palate	skos:exactMatch	mesh	C562950	Cleft Soft Palate	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110215	Leber congenital amaurosis 5	skos:exactMatch	mesh	C536602	Amaurosis congenita of Leber, type 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110216	Leber congenital amaurosis 11	skos:exactMatch	mesh	C564140	Leber Congenital Amaurosis 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110219	Brugada syndrome 2	skos:exactMatch	mesh	C567087	Brugada Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110220	Brugada syndrome 3	skos:exactMatch	mesh	C567509	Brugada Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110221	Brugada syndrome 4	skos:exactMatch	mesh	C567508	Brugada Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110222	Brugada syndrome 5	skos:exactMatch	mesh	C567556	Brugada Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110223	Brugada syndrome 6	skos:exactMatch	mesh	C567735	Brugada Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110224	Brugada syndrome 7	skos:exactMatch	mesh	C567734	Brugada Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110225	Brugada syndrome 8	skos:exactMatch	mesh	C567732	Brugada Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110291	Leber congenital amaurosis 10	skos:exactMatch	mesh	C565720	Leber Congenital Amaurosis 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110329	Leber congenital amaurosis 6	skos:exactMatch	mesh	C565327	Leber Congenital Amaurosis 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110330	Leber congenital amaurosis 13	skos:exactMatch	mesh	C567197	Leber Congenital Amaurosis 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110331	Leber congenital amaurosis 3	skos:exactMatch	mesh	C565814	Leber Congenital Amaurosis 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110332	Leber congenital amaurosis 4	skos:exactMatch	mesh	C565778	Leber Congenital Amaurosis 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110337	osteogenesis imperfecta type 7	skos:exactMatch	mesh	C565200	Osteogenesis Imperfecta Type VII	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110353	retinitis pigmentosa 20	skos:exactMatch	mesh	C566718	Retinitis Pigmentosa 20	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110354	retinitis pigmentosa 19	skos:exactMatch	mesh	C566637	Retinitis Pigmentosa 19	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110355	retinitis pigmentosa 32	skos:exactMatch	mesh	C563689	Retinitis Pigmentosa 32	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110356	retinitis pigmentosa 18	skos:exactMatch	mesh	C563320	Retinitis Pigmentosa 18	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110357	retinitis pigmentosa 35	skos:exactMatch	mesh	C565206	Retinitis Pigmentosa 35	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110358	retinitis pigmentosa 12	skos:exactMatch	mesh	C563999	Retinitis Pigmentosa 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110366	retinitis pigmentosa 33	skos:exactMatch	mesh	C563676	Retinitis Pigmentosa 33	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110368	retinitis pigmentosa 26	skos:exactMatch	mesh	C564249	Retinitis Pigmentosa 26	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110376	retinitis pigmentosa 41	skos:exactMatch	mesh	C567422	Retinitis Pigmentosa 41	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110378	retinitis pigmentosa 29	skos:exactMatch	mesh	C567403	Retinitis Pigmentosa 29	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110381	retinitis pigmentosa 14	skos:exactMatch	mesh	C563992	Retinitis Pigmentosa 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110383	retinitis pigmentosa 7	skos:exactMatch	mesh	C564284	Retinitis Pigmentosa 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110384	retinitis pigmentosa 25	skos:exactMatch	mesh	C566425	Retinitis Pigmentosa 25	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110386	retinitis pigmentosa 42	skos:exactMatch	mesh	C567854	Retinitis Pigmentosa 42	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110387	retinitis pigmentosa 9	skos:exactMatch	mesh	C566716	Retinitis Pigmentosa 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110388	retinitis pigmentosa 10	skos:exactMatch	mesh	C566715	Retinitis Pigmentosa 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110391	retinitis pigmentosa 31	skos:exactMatch	mesh	C563685	Retinitis Pigmentosa 31	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110397	retinitis pigmentosa 27	skos:exactMatch	mesh	C563526	Retinitis Pigmentosa 27	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110399	retinitis pigmentosa 37	skos:exactMatch	mesh	C567005	Retinitis Pigmentosa 37	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110403	retinitis pigmentosa 13	skos:exactMatch	mesh	C564008	Retinitis Pigmentosa 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110404	retinitis pigmentosa 17	skos:exactMatch	mesh	C563437	Retinitis Pigmentosa 17	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110405	retinitis pigmentosa 36	skos:exactMatch	mesh	C566431	Retinitis Pigmentosa 36	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110406	retinitis pigmentosa 30	skos:exactMatch	mesh	C564310	Retinitis Pigmentosa 30	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110408	retinitis pigmentosa 11	skos:exactMatch	mesh	C563991	Retinitis Pigmentosa 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110409	retinitis pigmentosa 46	skos:exactMatch	mesh	C567249	Retinitis Pigmentosa 46	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110413	retinitis pigmentosa 6	skos:exactMatch	mesh	C564065	Retinitis Pigmentosa 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110414	retinitis pigmentosa 3	skos:exactMatch	mesh	C564520	Retinitis Pigmentosa 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110415	retinitis pigmentosa 2	skos:exactMatch	mesh	C567523	Retinitis Pigmentosa 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110417	retinitis pigmentosa 34	skos:exactMatch	mesh	C564475	Retinitis Pigmentosa 34	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110630	Wolfram syndrome 2	skos:exactMatch	mesh	C565733	Wolfram Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110645	long QT syndrome 2	skos:exactMatch	mesh	C563614	Long Qt Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110646	long QT syndrome 3	skos:exactMatch	mesh	C565840	Long Qt Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110647	long QT syndrome 5	skos:exactMatch	mesh	C566766	Long Qt Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110648	long QT syndrome 6	skos:exactMatch	mesh	C566333	Long Qt Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110650	long QT syndrome 9	skos:exactMatch	mesh	C567515	Long Qt Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110651	long QT syndrome 10	skos:exactMatch	mesh	C567514	Long Qt Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110652	long QT syndrome 11	skos:exactMatch	mesh	C567513	Long Qt Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110653	long QT syndrome 12	skos:exactMatch	mesh	C567842	Long Qt Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110702	hypotrichosis 5	skos:exactMatch	mesh	C567554	Hypotrichosis 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110736	neurodegeneration with brain iron accumulation 2b	skos:exactMatch	mesh	C565699	NBIA2B	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110872	holoprosencephaly 2	skos:exactMatch	mesh	C563579	Holoprosencephaly 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110873	holoprosencephaly 9	skos:exactMatch	mesh	C563659	Holoprosencephaly 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110874	holoprosencephaly 6	skos:exactMatch	mesh	C565274	Holoprosencephaly 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110875	holoprosencephaly 3	skos:exactMatch	mesh	C564181	Holoprosencephaly 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110876	holoprosencephaly 7	skos:exactMatch	mesh	C563660	Holoprosencephaly 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110878	holoprosencephaly 5	skos:exactMatch	mesh	C566464	Holoprosencephaly 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110879	holoprosencephaly 8	skos:exactMatch	mesh	C563723	Holoprosencephaly 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110880	holoprosencephaly 4	skos:exactMatch	mesh	C564180	Holoprosencephaly 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110882	inflammatory bowel disease 7	skos:exactMatch	mesh	C565353	Inflammatory Bowel Disease 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110883	inflammatory bowel disease 17	skos:exactMatch	mesh	C567378	Inflammatory Bowel Disease 17	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110884	inflammatory bowel disease 23	skos:exactMatch	mesh	C567326	Inflammatory Bowel Disease 23	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110885	inflammatory bowel disease 10	skos:exactMatch	mesh	C567021	Inflammatory Bowel Disease 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110886	inflammatory bowel disease 9	skos:exactMatch	mesh	C563926	Inflammatory Bowel Disease 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110887	inflammatory bowel disease 12	skos:exactMatch	mesh	C567388	Inflammatory Bowel Disease 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110888	inflammatory bowel disease 18	skos:exactMatch	mesh	C567377	Inflammatory Bowel Disease 18	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110889	inflammatory bowel disease 5	skos:exactMatch	mesh	C565234	Inflammatory Bowel Disease 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110890	inflammatory bowel disease 19	skos:exactMatch	mesh	C567372	Inflammatory Bowel Disease 19	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110891	inflammatory bowel disease 3	skos:exactMatch	mesh	C565764	Inflammatory Bowel Disease 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110893	inflammatory bowel disease 13	skos:exactMatch	mesh	C567384	Inflammatory Bowel Disease 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110894	inflammatory bowel disease 11	skos:exactMatch	mesh	C567154	Inflammatory Bowel Disease 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110895	inflammatory bowel disease 14	skos:exactMatch	mesh	C567383	Inflammatory Bowel Disease 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110896	inflammatory bowel disease 16	skos:exactMatch	mesh	C567380	Inflammatory Bowel Disease 16	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110897	inflammatory bowel disease 15	skos:exactMatch	mesh	C567381	Inflammatory Bowel Disease 15	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110898	inflammatory bowel disease 20	skos:exactMatch	mesh	C567361	Inflammatory Bowel Disease 20	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110900	inflammatory bowel disease 2	skos:exactMatch	mesh	C563310	Inflammatory Bowel Disease 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110901	inflammatory bowel disease 26	skos:exactMatch	mesh	C567217	Inflammatory Bowel Disease 26	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110902	inflammatory bowel disease 27	skos:exactMatch	mesh	C567559	Inflammatory Bowel Disease 27	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110903	inflammatory bowel disease 4	skos:exactMatch	mesh	C564680	Inflammatory Bowel Disease 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110904	inflammatory bowel disease 8	skos:exactMatch	mesh	C564682	Inflammatory Bowel Disease 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110905	inflammatory bowel disease 22	skos:exactMatch	mesh	C567327	Inflammatory Bowel Disease 22	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110906	inflammatory bowel disease 21	skos:exactMatch	mesh	C567338	Inflammatory Bowel Disease 21	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110907	inflammatory bowel disease 6	skos:exactMatch	mesh	C564681	Inflammatory Bowel Disease 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110908	inflammatory bowel disease 24	skos:exactMatch	mesh	C567252	Inflammatory Bowel Disease 24	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110912	leukocyte adhesion deficiency 3	skos:exactMatch	mesh	C567555	Leukocyte Adhesion Deficiency, Type III	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110926	nemaline myopathy 1	skos:exactMatch	mesh	C538348	Nemaline myopathy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110928	nemaline myopathy 2	skos:exactMatch	mesh	C538349	Nemaline Myopathy 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110932	nemaline myopathy 4	skos:exactMatch	mesh	C538351	Nemaline myopathy 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110934	nemaline myopathy 7	skos:exactMatch	mesh	C565198	Nemaline Myopathy 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110935	nemaline myopathy 6	skos:exactMatch	mesh	C538398	Nemaline myopathy 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110936	nemaline myopathy 5	skos:exactMatch	mesh	C538397	Nemaline myopathy 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110947	Waardenburg syndrome type 2B	skos:exactMatch	mesh	C536465	Waardenburg syndrome type 2B	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110950	Waardenburg syndrome type 2A	skos:exactMatch	mesh	C536464	Waardenburg syndrome type 2A	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110964	brachydactyly type A1	skos:exactMatch	mesh	C537088	Brachydactyly type A1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0110966	brachydactyly type A3	skos:exactMatch	mesh	C537090	Brachydactyly type A3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111009	cone-rod dystrophy 1	skos:exactMatch	mesh	C563469	Cone-Rod Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111010	cone-rod dystrophy 5	skos:exactMatch	mesh	C563415	Cone-Rod Dystrophy 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111012	cone-rod dystrophy 7	skos:exactMatch	mesh	C566350	Cone-Rod Dystrophy 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111013	cone-rod dystrophy 3	skos:exactMatch	mesh	C565827	Cone-Rod Dystrophy 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111014	cone-rod dystrophy 8	skos:exactMatch	mesh	C565322	Cone-Rod Dystrophy 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111016	cone-rod dystrophy 13	skos:exactMatch	mesh	C567698	Cone-Rod Dystrophy 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111017	cone-rod dystrophy 10	skos:exactMatch	mesh	C564597	Cone-Rod Dystrophy 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111018	cone-rod dystrophy 11	skos:exactMatch	mesh	C563671	Cone-Rod Dystrophy 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111019	cone-rod dystrophy 12	skos:exactMatch	mesh	C567206	Cone-Rod Dystrophy 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111041	glycogen storage disease IXb	skos:exactMatch	mesh	C563008	Glycogen Storage Disease IXB	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111043	glycogen storage disease IXc	skos:exactMatch	mesh	C567809	Glycogen Storage Disease IXC	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111079	birdshot chorioretinopathy	skos:exactMatch	mesh	D000080365	Birdshot Chorioretinopathy	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0111079	birdshot chorioretinopathy	skos:exactMatch	umls	C1853959	Birdshot Chorioretinopathy	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0111086	Fanconi anemia complementation group G	skos:exactMatch	efo	0009046	Fanconi anemia complementation group G	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111088	Fanconi anemia complementation group F	skos:exactMatch	efo	0009045	Fanconi anemia complementation group F	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111095	Fanconi anemia complementation group A	skos:exactMatch	efo	0009044	Fanconi anemia complementation group A	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111113	nephronophthisis 2	skos:exactMatch	mesh	C566582	Nephronophthisis 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111114	nephronophthisis 3	skos:exactMatch	mesh	C565780	Nephronophthisis 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111115	nephronophthisis 4	skos:exactMatch	mesh	C564640	Nephronophthisis 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111116	nephronophthisis 7	skos:exactMatch	mesh	C566930	Nephronophthisis 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111129	focal segmental glomerulosclerosis 2	skos:exactMatch	mesh	C565831	Focal Segmental Glomerulosclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111130	focal segmental glomerulosclerosis 5	skos:exactMatch	mesh	C567687	Focal Segmental Glomerulosclerosis 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111139	mitochondrial complex III deficiency	skos:exactMatch	mesh	C565128	Mitochondrial Complex III Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111144	preterm premature rupture of the membranes	skos:exactMatch	mesh	C563032	Preterm Premature Rupture of the Membranes	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111162	epidermal nevus	skos:exactMatch	mesh	C580062	Epidermal Nevus	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111165	molybdenum cofactor deficiency	skos:exactMatch	mesh	C535811	Molybdenum cofactor deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111167	Dyggve-Melchior-Clausen disease	skos:exactMatch	mesh	C535726	Dyggve-Melchior-Clausen syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111218	Friedreich ataxia 1	skos:exactMatch	mesh	C565561	Friedreich Ataxia 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111219	Friedreich ataxia 2	skos:exactMatch	mesh	C566594	Friedreich Ataxia 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111227	chromosome 3-linked frontotemporal dementia	skos:exactMatch	mesh	C579991	Chromosome 3-Linked Frontotemporal Dementia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111330	combined saposin deficiency	skos:exactMatch	mesh	C567125	Combined Saposin Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111347	epidermolysis bullosa with congenital localized absence of skin and deformity of nails	skos:exactMatch	mesh	C562638	Epidermolysis Bullosa With Congenital Localized Absence Of Skin And Deformity Of Nails	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111355	hydrolethalus syndrome 1	skos:exactMatch	mesh	C565504	Hydrolethalus Syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111370	apolipoprotein C-III deficiency	skos:exactMatch	mesh	C566270	Apolipoprotein C-III Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111408	exudative vitreoretinopathy 5	skos:exactMatch	mesh	C567648	Exudative Vitreoretinopathy 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111409	exudative vitreoretinopathy 3	skos:exactMatch	mesh	C565297	Exudative Vitreoretinopathy 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111411	exudative vitreoretinopathy 4	skos:exactMatch	mesh	C566619	Exudative Vitreoretinopathy 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111412	exudative vitreoretinopathy 1	skos:exactMatch	mesh	C536382	Exudative vitreoretinopathy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111435	optic atrophy 6	skos:exactMatch	mesh	C537127	Optic atrophy 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111437	optic atrophy 7	skos:exactMatch	mesh	C567833	Optic Atrophy 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111438	optic atrophy 5	skos:exactMatch	mesh	C537126	Optic atrophy 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111440	optic atrophy 4	skos:exactMatch	mesh	C565343	Optic Atrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111473	combined oxidative phosphorylation deficiency 5	skos:exactMatch	mesh	C567126	Combined Oxidative Phosphorylation Deficiency 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111483	combined oxidative phosphorylation deficiency 2	skos:exactMatch	mesh	C566468	Combined Oxidative Phosphorylation Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111495	combined oxidative phosphorylation deficiency 33	skos:exactMatch	efo	0009159	combined oxidative phosphorylation deficiency 33	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111504	Li-Fraumeni syndrome 2	skos:exactMatch	mesh	C563755	Li-Fraumeni Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111552	scapuloperoneal spinal muscular atrophy	skos:exactMatch	efo	1001992	Scapuloperoneal spinal muscular atrophy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111560	Charcot-Marie-Tooth disease type 1G	skos:exactMatch	efo	0010266	Charcot-Marie-Tooth disease type 1G	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111701	long QT syndrome 4	skos:exactMatch	mesh	C563428	Long Qt Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111771	46,XY sex reversal 4	skos:exactMatch	mesh	C567887	46,XY Sex Reversal 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0111820	zygodactyly 1	skos:exactMatch	mesh	C565223	Zygodactyly 1	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111841	Shukla-Vernon syndrome	skos:exactMatch	efo	0010278	Shukla-Vernon syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111843	Paganini-Miozzo syndrome	skos:exactMatch	efo	0010261	Paganini-Miozzo syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112148	Uruguay faciocardiomusculoskeletal syndrome	skos:exactMatch	mesh	C564544	Uruguay Faciocardiomusculoskeletal Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112184	thyroid dyshormonogenesis 5	skos:exactMatch	mesh	C562771	Thyroid Dyshormonogenesis 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112185	thyroid dyshormonogenesis 1	skos:exactMatch	mesh	C564766	Thyroid Dyshormonogenesis 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112186	thyroid dyshormonogenesis 2A	skos:exactMatch	mesh	C563206	Thyroid Dyshormonogenesis 2A	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112187	thyroid dyshormonogenesis 3	skos:exactMatch	mesh	C562769	Thyroid Dyshormonogenesis 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112188	thyroid dyshormonogenesis 4	skos:exactMatch	mesh	C562770	Thyroid Dyshormonogenesis 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112189	thyroid dyshormonogenesis 6	skos:exactMatch	mesh	C564608	Thyroid Dyshormonogenesis 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112194	Filippi syndrome	skos:exactMatch	mesh	C538152	Filippi syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112232	lissencephaly 3	skos:exactMatch	mesh	C566908	Lissencephaly 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112244	alopecia, neurologic defects, and endocrinopathy syndrome	skos:exactMatch	mesh	C567425	Alopecia, Neurologic Defects, and Endocrinopathy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112257	hydroxykynureninuria	skos:exactMatch	mesh	C536081	Hydroxykynureninuria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112258	N-acetylglutamate synthase deficiency	skos:exactMatch	mesh	C536109	N-acetyl glutamate synthetase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112259	Leydig cell hypoplasia	skos:exactMatch	mesh	C562567	Leydig Cell Hypoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112286	spondyloepiphyseal dysplasia with punctate corneal dystrophy	skos:exactMatch	mesh	C566660	Spondyloepiphyseal Dysplasia With Punctate Corneal Dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112289	spondyloepiphyseal dysplasia tarda with characteristic facies	skos:exactMatch	mesh	C564003	Spondyloepiphyseal Dysplasia Tarda with Characteristic Facies	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112322	pontocerebellar hypoplasia type 1	skos:exactMatch	mesh	C548069	Pontocerebellar Hypoplasia Type 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0112328	pontocerebellar hypoplasia type 2	skos:exactMatch	mesh	C548070	Pontocerebellar Hypoplasia Type 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:10032	hyperlucent lung	skos:exactMatch	mesh	D019568	Lung, Hyperlucent	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:10032	hyperlucent lung	skos:exactMatch	umls	C0524799	Lung, Hyperlucent	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:1019	osteomyelitis	skos:exactMatch	mesh	D010019	Osteomyelitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:10247	pleurisy	skos:exactMatch	mesh	D010998	Pleurisy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:10573	osteomalacia	skos:exactMatch	efo	1002027	osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:10573	osteomalacia	skos:exactMatch	mesh	D010018	Osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1059	intellectual disability	skos:exactMatch	mesh	D008607	Intellectual Disability	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:10854	salivary gland disease	skos:exactMatch	mesh	D012466	Salivary Gland Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1088	meningocele	skos:exactMatch	mesh	D008588	Meningocele	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:11263	chlamydia	skos:exactMatch	mesh	D002689	Chlamydia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:11294	arteriovenous malformation	skos:exactMatch	mesh	D001165	Arteriovenous Malformations	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:11613	hyperandrogenism	skos:exactMatch	efo	0009006	hyperandrogenism	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:11758	iron deficiency anemia	skos:exactMatch	mesh	D018798	Anemia, Iron-Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:11917	tinea cruris	skos:exactMatch	mesh	D000084002	Tinea cruris	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:12140	Chagas disease	skos:exactMatch	mesh	D014355	Chagas Disease	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:12351	alcoholic hepatitis	skos:exactMatch	mesh	D006519	Hepatitis, Alcoholic	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1307	dementia	skos:exactMatch	mesh	D003704	Dementia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:13403	neurosarcoidosis	skos:exactMatch	mesh	C535814	Neurosarcoidosis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1373	endometrial stromal nodule	skos:exactMatch	efo	1000241	Endometrial Stromal Nodule	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:13891	bird fancier's lung	skos:exactMatch	mesh	D001716	Bird Fancier's Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:13891	bird fancier's lung	skos:exactMatch	umls	C0005592	Bird Fancier's Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:13938	amenorrhea	skos:exactMatch	efo	0010269	amenorrhea	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1395	schistosomiasis	skos:exactMatch	mesh	D012552	Schistosomiasis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:13957	uterine corpus lipoleiomyoma	skos:exactMatch	efo	1000614	Uterine Corpus Lipoleiomyoma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1432	blindness	skos:exactMatch	mesh	D001766	Blindness	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:14453	farmer's lung	skos:exactMatch	mesh	D005203	Farmer's Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:14453	farmer's lung	skos:exactMatch	umls	C0015634	Farmer's Lung	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:1470	major depressive disorder	skos:exactMatch	mesh	D003865	Depressive Disorder, Major	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:14749	methylmalonic acidemia	skos:exactMatch	mesh	C537358	Methylmalonic acidemia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:14764	Larsen syndrome	skos:exactMatch	mesh	C580241	Larsen Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1529	penile disease	skos:exactMatch	mesh	D010409	Penile Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1555	urticaria	skos:exactMatch	mesh	D014581	Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1575	rheumatic disease	skos:exactMatch	mesh	D012216	Rheumatic Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1673	pneumothorax	skos:exactMatch	mesh	D011030	Pneumothorax	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1788	peritoneal mesothelioma	skos:exactMatch	efo	1000467	Peritoneal Mesothelioma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:1829	urethral stricture	skos:exactMatch	mesh	D014525	Urethral Stricture	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1920	hyperuricemia	skos:exactMatch	efo	0009104	hyperuricemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2001	neuroma	skos:exactMatch	efo	0009619	neuroma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:2123	tularemia	skos:exactMatch	mesh	D014406	Tularemia	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:2176	carbuncle	skos:exactMatch	mesh	D002270	Carbuncle	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2626	choroid plexus papilloma	skos:exactMatch	efo	1000177	Choroid Plexus Papilloma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2708	mushroom workers' lung	skos:exactMatch	umls	C0155889	Mushroom Worker's Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:2784	lung sarcoma	skos:exactMatch	umls	C0598790	Sarcoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
@@ -2839,15 +2921,23 @@ doid	DOID:3907	lung squamous cell carcinoma	skos:exactMatch	umls	C0149782	Squamo
 doid	DOID:3908	lung non-small cell carcinoma	skos:exactMatch	umls	C0007131	Non-Small Cell Lung Carcinoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:3910	lung adenocarcinoma	skos:exactMatch	mesh	D000077192	Adenocarcinoma of Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:3910	lung adenocarcinoma	skos:exactMatch	umls	C0152013	Adenocarcinoma of lung (disorder)	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:3965	Merkel cell carcinoma	skos:exactMatch	mesh	D015266	Carcinoma, Merkel Cell	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:4001	ovarian carcinoma	skos:exactMatch	umls	C0029925	Ovarian Carcinoma	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:4156	primary syphilis	skos:exactMatch	mesh	C536772	Syphilis, primary	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:417	autoimmune disease	skos:exactMatch	mesh	D001327	Autoimmune Diseases	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:4337	tinea capitis	skos:exactMatch	mesh	D014006	Tinea Capitis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:4492	avian influenza	skos:exactMatch	mesh	D005585	Influenza in Birds	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4492	avian influenza	skos:exactMatch	umls	C0016627	Influenza in Birds	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:4500	hypokalemia	skos:exactMatch	mesh	D007008	Hypokalemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:4556	lung large cell carcinoma	skos:exactMatch	umls	C0345958	Large cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4829	adenosquamous lung carcinoma	skos:exactMatch	umls	C0279557	Adenosquamous cell lung cancer	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4872	lung adenoid cystic carcinoma	skos:exactMatch	umls	C1334439	adenoid cystic carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:490	hemangioma of lung	skos:exactMatch	umls	C0241983	hemangioma of lung	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:507	adjustment disorder	skos:exactMatch	mesh	D000275	Adjustment Disorders	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:5136	lung leiomyoma	skos:exactMatch	umls	C1334447	Leiomyoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:5199	ureteral obstruction	skos:exactMatch	mesh	D014517	Ureteral Obstruction	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:5265	lung leiomyosarcoma	skos:exactMatch	umls	C1334448	leiomyosarcoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
+doid	DOID:528	hydrarthrosis	skos:exactMatch	mesh	D006833	Hydrarthrosis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:5386	lung adenoma	skos:exactMatch	umls	C0345964	Adenoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:5409	lung small cell carcinoma	skos:exactMatch	umls	C0149925	Small cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:5583	lung giant cell carcinoma	skos:exactMatch	umls	C0345960	Giant cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -3460,7 +3460,7 @@ mesh	C535327	Holzgreve Wagner Rehder syndrome	skos:exactMatch	doid	DOID:0060566	
 mesh	C535328	Homocarnosinosis	skos:exactMatch	doid	DOID:0060177	homocarnosinosis	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535330	Aagenaes syndrome	skos:exactMatch	doid	DOID:6691	Aagenaes syndrome	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535334	ABCD syndrome	skos:exactMatch	doid	DOID:0050600	ABCD syndrome	manually_reviewed	orcid:0000-0003-4423-4370
-mesh	C535347	Catel Manzke syndrome	skos:exactMatch	doid	0081122	Catel Manzke syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C535347	Catel Manzke syndrome	skos:exactMatch	doid	DOID:0081122	Catel Manzke syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535358	Choroidal sclerosis	skos:exactMatch	doid	DOID:980	choroidal sclerosis	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535362	Chromosome 1p36 Deletion Syndrome	skos:exactMatch	doid	DOID:0060410	chromosome 1p36 deletion syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535374	Dermatopathia pigmentosa reticularis	skos:exactMatch	doid	DOID:0111342	dermatopathia pigmentosa reticularis	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3502,15 +3502,15 @@ mesh	C535557	Ablepharon macrostomia syndrome	skos:exactMatch	doid	DOID:0060550	a
 mesh	C535564	Absence of tibia with polydactyly	skos:exactMatch	doid	DOID:0111564	hypoplastic or aplastic tibia with polydactyly	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535566	Absent corpus callosum cataract immunodeficiency	skos:exactMatch	doid	DOID:0060356	Vici syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535572	Cantu syndrome	skos:exactMatch	doid	DOID:0060569	hypertrichotic osteochondrodysplasia Cantu type	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C535579	Cardiofaciocutaneous syndrome	skos:exactMatch	doid	0060233	cardiofaciocutaneous syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C535579	Cardiofaciocutaneous syndrome	skos:exactMatch	doid	DOID:0060233	cardiofaciocutaneous syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535581	Cardiomyopathy dilated with Woolly hair and keratoderma	skos:exactMatch	doid	DOID:0090128	Carvajal syndrome	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C535588	Carnitine palmitoyl transferase 1A deficiency	skos:exactMatch	doid	0090129	carnitine palmitoyltransferase I deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C535588	Carnitine palmitoyl transferase 1A deficiency	skos:exactMatch	doid	DOID:0090129	carnitine palmitoyltransferase I deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535600	dopamine beta hydroxylase deficiency	skos:exactMatch	doid	DOID:0090145	dopamine beta-hydroxylase deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535601	Dosage-sensitive sex reversal	skos:exactMatch	doid	DOID:0111777	46,XY sex reversal 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535602	Doyne honeycomb retinal dystrophy	skos:exactMatch	doid	DOID:0060745	Doyne honeycomb retinal dystrophy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535607	Aicardi-Goutieres syndrome	skos:exactMatch	doid	DOID:0050629	Aicardi-Goutieres syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535627	Hand foot uterus syndrome	skos:exactMatch	doid	DOID:0060739	hand-foot-genital syndrome	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C535642	Growth retardation, Alopecia, Pseudoanodontia and Optic atrophy	skos:exactMatch	doid	0112249	GAPO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C535642	Growth retardation, Alopecia, Pseudoanodontia and Optic atrophy	skos:exactMatch	doid	DOID:0112249	GAPO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535658	Acromesomelic dysplasia	skos:exactMatch	doid	DOID:0080049	acromesomelic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535661	Acromesomelic dysplasia, Maroteaux type	skos:exactMatch	doid	DOID:0080050	acromesomelic dysplasia, Maroteaux type	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535662	Acromicric dysplasia	skos:exactMatch	doid	DOID:0111243	acromicric dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3591,7 +3591,7 @@ mesh	C536141	Megalencephalic leukoencephalopathy with subcortical cysts	skos:exa
 mesh	C536149	Melanoma astrocytoma syndrome	skos:exactMatch	doid	DOID:0111511	melanoma and neural system tumor syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536152	Palmoplantar Keratoderma with Deafness	skos:exactMatch	doid	DOID:0111505	palmoplantar keratoderma-deafness syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536156	Keratomalacia	skos:exactMatch	doid	DOID:11267	keratomalacia	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C536162	Keratosis palmoplantaris striata 1	skos:exactMatch	doid	0081108	keratosis palmoplantaris striata 1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C536162	Keratosis palmoplantaris striata 1	skos:exactMatch	doid	DOID:0081108	keratosis palmoplantaris striata 1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536164	Keratosis palmoplantaris with esophageal cancer	skos:exactMatch	doid	DOID:0111506	palmoplantar keratoderma-esophageal carcinoma syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536166	Keshan disease	skos:exactMatch	doid	DOID:0050083	Keshan disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536170	Diastrophic dysplasia	skos:exactMatch	doid	DOID:14687	diastrophic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3621,7 +3621,7 @@ mesh	C536309	Patterned dystrophy of retinal pigment epithelium	skos:exactMatch	d
 mesh	C536317	PEHO syndrome	skos:exactMatch	doid	DOID:0080539	PEHO syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536321	Poikiloderma of Kindler	skos:exactMatch	doid	DOID:0060472	Kindler syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536329	Polycystic lipomembranous osteodysplasia with sclerosing leukoencephalopathy	skos:exactMatch	doid	DOID:0090112	Nasu-Hakola disease	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C536330	Polycystic liver disease	skos:exactMatch	doid	0050770	polycystic liver disease	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C536330	Polycystic liver disease	skos:exactMatch	doid	DOID:0050770	polycystic liver disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536335	Polyostotic osteolytic dysplasia, hereditary expansile	skos:exactMatch	doid	DOID:0111542	familial expansile osteolysis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536352	Vitreoretinochoroidopathy	skos:exactMatch	doid	DOID:0111569	autosomal dominant vitreoretinochoroidopathy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536358	Anemia, sideroblastic spinocerebellar ataxia	skos:exactMatch	doid	DOID:0050554	X-linked sideroblastic anemia with ataxia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3718,9 +3718,9 @@ mesh	C536959	Temtamy syndrome	skos:exactMatch	doid	DOID:0111621	Temtamy syndrome
 mesh	C536962	Timothy syndrome	skos:exactMatch	doid	DOID:0060173	Timothy syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536965	Tomaculous neuropathy	skos:exactMatch	doid	DOID:0060843	hereditary neuropathy with liability to pressure palsies	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536969	Torsion dystonia with onset in infancy	skos:exactMatch	doid	DOID:0090058	torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C536974	Townes-Brocks syndrome	skos:exactMatch	doid	0050887	Townes-Brocks syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C536974	Townes-Brocks syndrome	skos:exactMatch	doid	DOID:0050887	Townes-Brocks syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536979	Transient bullous dermolysis of the newborn	skos:exactMatch	doid	DOID:0111345	transient bullous dermolysis of the newborn	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	0080688	mosaic variegated aneuploidy syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	DOID:0080688	mosaic variegated aneuploidy syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	DOID:0080141	mosaic variegated aneuploidy syndrome 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536990	Mowat-Wilson syndrome	skos:exactMatch	doid	DOID:0060485	Mowat-Wilson syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537005	Complement component 5 deficiency	skos:exactMatch	doid	DOID:8158	complement component 5 deficiency	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3776,7 +3776,7 @@ mesh	C537247	Hemochromatosis, type 2	skos:exactMatch	doid	DOID:0111034	hemochrom
 mesh	C537248	Hemochromatosis, type 3	skos:exactMatch	doid	DOID:0111030	hemochromatosis type 3	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537249	Hemochromatosis, type 4	skos:exactMatch	doid	DOID:0111028	hemochromatosis type 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537255	Hennekam lymphangiectasia lymphedema syndrome	skos:exactMatch	doid	DOID:0060366	Hennekam syndrome	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C537257	Hepatic venoocclusive disease with immunodeficiency	skos:exactMatch	doid	0112254	hepatic venoocclusive disease with immunodeficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C537257	Hepatic venoocclusive disease with immunodeficiency	skos:exactMatch	doid	DOID:0112254	hepatic venoocclusive disease with immunodeficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537258	Fibrolamellar hepatocellular carcinoma	skos:exactMatch	doid	DOID:5015	fibrolamellar carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537262	Hereditary pancreatitis	skos:exactMatch	ncit	C95436	Hereditary Pancreatitis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537264	Lamellar ichthyosis, type 2	skos:exactMatch	doid	DOID:0060712	autosomal recessive congenital ichthyosis 4A	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3791,9 +3791,9 @@ mesh	C537310	Spinocerebellar ataxia, autosomal recessive 4	skos:exactMatch	doid	
 mesh	C537327	SHORT syndrome	skos:exactMatch	doid	DOID:0111454	SHORT syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537333	Siderius X-linked mental retardation syndrome	skos:exactMatch	doid	DOID:0060812	syndromic X-linked intellectual disability Siderius type	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537340	Simpson-Golabi-Behmel syndrome	skos:exactMatch	doid	DOID:0060248	Simpson-Golabi-Behmel syndrome type 1	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C537344	Sinonasal undifferentiated carcinoma	skos:exactMatch	doid	0080799	sinonasal undifferentiated carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C537344	Sinonasal undifferentiated carcinoma	skos:exactMatch	doid	DOID:0080799	sinonasal undifferentiated carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537356	Metatropic dwarfism	skos:exactMatch	doid	DOID:0111514	metatropic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C537360	Methylmalonic aciduria cblA type	skos:exactMatch	doid	0060742	methylmalonic acidemia cblA type	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C537360	Methylmalonic aciduria cblA type	skos:exactMatch	doid	DOID:0060742	methylmalonic acidemia cblA type	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537361	Methylmalonic aciduria cblB type	skos:exactMatch	efo	0009074	methylmalonic aciduria cblb type	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537362	Immunodeficiency syndrome, variable	skos:exactMatch	doid	DOID:0090007	immunodeficiency-centromeric instability-facial anomalies syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537369	Muenke Syndrome	skos:exactMatch	doid	DOID:0060703	Muenke Syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4023,7 +4023,7 @@ mesh	C562924	Dowling-Degos Disease	skos:exactMatch	doid	DOID:0060256	Dowling-Deg
 mesh	C562938	Metachondromatosis	skos:exactMatch	doid	DOID:0111512	metachondromatosis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562943	Choroid Plexus Carcinoma	skos:exactMatch	doid	DOID:5648	choroid plexus carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C562950	Cleft Soft Palate	skos:exactMatch	doid	DOID:0110214	cleft soft palate	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C562968	Spondyloepimetaphyseal Dysplasia With Joint Laxity	skos:exactMatch	doid	0112197	spondyloepimetaphyseal dysplasia with joint laxity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C562968	Spondyloepimetaphyseal Dysplasia With Joint Laxity	skos:exactMatch	doid	DOID:0112197	spondyloepimetaphyseal dysplasia with joint laxity	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563003	Pallidopontonigral Degeneration	skos:exactMatch	doid	DOID:9255	frontotemporal dementia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563008	Glycogen Storage Disease IXB	skos:exactMatch	doid	DOID:0111041	glycogen storage disease IXb	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563032	Preterm Premature Rupture of the Membranes	skos:exactMatch	doid	DOID:0111144	preterm premature rupture of the membranes	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4060,12 +4060,12 @@ mesh	C563399	Epilepsy, Myoclonic, Benign Adult Familial, Type 1	skos:exactMatch	
 mesh	C563401	Choreoathetosis-Spasticity, Episodic	skos:exactMatch	doid	DOID:0090044	dystonia 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563409	Arrhythmogenic Right Ventricular Dysplasia, Familial, 2	skos:exactMatch	doid	DOID:0110071	arrhythmogenic right ventricular dysplasia 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563410	Deafness, Autosomal Dominant 5	skos:exactMatch	doid	DOID:0110575	autosomal dominant nonsyndromic deafness 5	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C563412	Juvenile Polyposis with Hereditary Hemorrhagic Telangiectasia	skos:exactMatch	doid	0111543	juvenile polyposis-hereditary hemorrhagic telangiectasia syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C563412	Juvenile Polyposis with Hereditary Hemorrhagic Telangiectasia	skos:exactMatch	doid	DOID:0111543	juvenile polyposis-hereditary hemorrhagic telangiectasia syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563415	Cone-Rod Dystrophy 5	skos:exactMatch	doid	DOID:0111010	cone-rod dystrophy 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563417	Deafness, Autosomal Recessive 7	skos:exactMatch	doid	DOID:0110520	autosomal recessive nonsyndromic deafness 7	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563421	Deafness, Autosomal Dominant 6	skos:exactMatch	doid	DOID:0110584	autosomal dominant nonsyndromic deafness 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563423	Proprotein Convertase 1 3 Deficiency	skos:exactMatch	doid	DOID:0111698	proprotein convertase 1/3 deficiency	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C563425	Diabetes Mellitus, Permanent Neonatal	skos:exactMatch	doid	0060639	permanent neonatal diabetes mellitus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C563425	Diabetes Mellitus, Permanent Neonatal	skos:exactMatch	doid	DOID:0060639	permanent neonatal diabetes mellitus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563428	Long Qt Syndrome 4	skos:exactMatch	doid	DOID:0111701	long QT syndrome 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563433	Diabetes Mellitus, Insulin-Dependent, 8	skos:exactMatch	doid	DOID:0110747	type 1 diabetes mellitus 8	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563437	Retinitis Pigmentosa 17	skos:exactMatch	doid	DOID:0110404	retinitis pigmentosa 17	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4109,7 +4109,7 @@ mesh	C563789	Peripheral Demyelinating Neuropathy, Central Dysmyelination, Waarde
 mesh	C563794	Limb-Girdle Muscular Dystrophy, Type 1G	skos:exactMatch	doid	DOID:0110306	autosomal dominant limb-girdle muscular dystrophy type 3	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563808	Arrhythmogenic Right Ventricular Dysplasia, Familial, 9	skos:exactMatch	doid	DOID:0110077	arrhythmogenic right ventricular dysplasia 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563815	Deafness, Autosomal Recessive 36	skos:exactMatch	doid	DOID:0110494	autosomal recessive nonsyndromic deafness 36	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C563822	Severe Combined Immunodeficiency, Autosomal Recessive, T Cell Negative, B Cell Positive, NK Cell Positive	skos:exactMatch	doid	0090014	severe combined immunodeficiency, autosomal recessive, T cell-negative, B cell-positive, Nk cell-positive	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C563822	Severe Combined Immunodeficiency, Autosomal Recessive, T Cell Negative, B Cell Positive, NK Cell Positive	skos:exactMatch	doid	DOID:0090014	severe combined immunodeficiency, autosomal recessive, T cell-negative, B cell-positive, Nk cell-positive	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C563843	Orofacial Cleft 5	skos:exactMatch	doid	DOID:0080399	orofacial cleft 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563848	Alpha-B Crystallinopathy	skos:exactMatch	doid	DOID:0080093	myofibrillar myopathy 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C563854	Muscular Dystrophy, Limb-Girdle, Type 2J	skos:exactMatch	doid	DOID:0110283	autosomal recessive limb-girdle muscular dystrophy type 2J	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4210,7 +4210,7 @@ mesh	C564738	Pontocerebellar Hypoplasia Type 2A	skos:exactMatch	doid	DOID:006026
 mesh	C564815	Spastic Ataxia	skos:exactMatch	doid	DOID:0050952	spastic ataxia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C564818	Peeling Skin Syndrome	skos:exactMatch	doid	DOID:0060283	peeling skin syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C564835	Enhanced S-Cone Syndrome	skos:exactMatch	doid	DOID:0090059	enhanced S-cone syndrome	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C564858	Pyruvate Kinase Deficiency of Red Cells	skos:exactMatch	doid	0111077	pyruvate kinase deficiency of red cells	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C564858	Pyruvate Kinase Deficiency of Red Cells	skos:exactMatch	doid	DOID:0111077	pyruvate kinase deficiency of red cells	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C564888	Glycogen Storage Disease of Heart, Lethal Congenital	skos:exactMatch	doid	DOID:0090101	lethal congenital glycogen storage disease of heart	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C564963	Leigh Syndrome due to Mitochondrial Complex IV Deficiency	skos:exactMatch	efo	0009135	leigh syndrome due to mitochondrial complex iv deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565070	Cleft Lip with or without Cleft Palate, Nonsyndromic, 8	skos:exactMatch	doid	DOID:0080401	orofacial cleft 8	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4250,12 +4250,12 @@ mesh	C565322	Cone-Rod Dystrophy 8	skos:exactMatch	doid	DOID:0111014	cone-rod dys
 mesh	C565325	Alzheimer Disease 6	skos:exactMatch	doid	DOID:0110038	Alzheimer's disease 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565327	Leber Congenital Amaurosis 6	skos:exactMatch	doid	DOID:0110329	Leber congenital amaurosis 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565329	Deafness, Autosomal Recessive 26	skos:exactMatch	doid	DOID:0110484	autosomal recessive nonsyndromic deafness 26	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C565342	Macrocephaly Autism Syndrome	skos:exactMatch	doid	0060867	macrocephaly-autism syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C565342	Macrocephaly Autism Syndrome	skos:exactMatch	doid	DOID:0060867	macrocephaly-autism syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565343	Optic Atrophy 4	skos:exactMatch	doid	DOID:0111440	optic atrophy 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565353	Inflammatory Bowel Disease 7	skos:exactMatch	doid	DOID:0110882	inflammatory bowel disease 7	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565357	Deafness, Autosomal Dominant 23	skos:exactMatch	doid	DOID:0110553	autosomal dominant nonsyndromic deafness 23	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565375	Mitochondrial Complex II Deficiency	skos:exactMatch	doid	DOID:0060537	mitochondrial complex II deficiency	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C565390	Methylmalonic Aciduria due to Methylmalonyl-CoA Mutase Deficiency	skos:exactMatch	doid	0060740	methylmalonic aciduria due to methylmalonyl-CoA mutase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C565390	Methylmalonic Aciduria due to Methylmalonyl-CoA Mutase Deficiency	skos:exactMatch	doid	DOID:0060740	methylmalonic aciduria due to methylmalonyl-CoA mutase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565393	3-Methylglutaconic Aciduria Type IV	skos:exactMatch	doid	DOID:0110006	3-methylglutaconic aciduria type 4	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565409	MAST Syndrome	skos:exactMatch	doid	DOID:0060245	Mast syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565452	Kniest-Like Dysplasia with Pursed Lips and Ectopia Lentis	skos:exactMatch	doid	DOID:0090005	Schwartz-Jampel syndrome 1	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4290,7 +4290,7 @@ mesh	C565778	Leber Congenital Amaurosis 4	skos:exactMatch	doid	DOID:0110332	Lebe
 mesh	C565780	Nephronophthisis 3	skos:exactMatch	doid	DOID:0111114	nephronophthisis 3	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565784	Cardioencephalomyopathy, Fatal Infantile, due to Cytochrome C Oxidase Deficiency	skos:exactMatch	doid	DOID:0050713	fatal infantile cardioencephalomyopathy due to cytochrome c oxidase deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565798	Rheumatoid Arthritis, Systemic Juvenile	skos:exactMatch	doid	DOID:676	juvenile rheumatoid arthritis	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C565808	Generalized Epilepsy with Febrile Seizures Plus	skos:exactMatch	doid	0060170	generalized epilepsy with febrile seizures plus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C565808	Generalized Epilepsy with Febrile Seizures Plus	skos:exactMatch	doid	DOID:0060170	generalized epilepsy with febrile seizures plus	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565809	Generalized Epilepsy With Febrile Seizures Plus, Type 1	skos:exactMatch	doid	DOID:0111302	generalized epilepsy with febrile seizures plus 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565810	Generalized Epilepsy With Febrile Seizures Plus, Type 2	skos:exactMatch	doid	DOID:0111294	generalized epilepsy with febrile seizures plus 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565814	Leber Congenital Amaurosis 3	skos:exactMatch	doid	DOID:0110331	Leber congenital amaurosis 3	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4319,7 +4319,7 @@ mesh	C565957	Amyotrophic Lateral Sclerosis 2, Juvenile	skos:exactMatch	doid	DOID
 mesh	C565974	Familial Glucocorticoid Deficiency 1	skos:exactMatch	doid	DOID:0080621	glucocorticoid deficiency 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566000	Glycoprotein IA Deficiency	skos:exactMatch	doid	DOID:0111045	platelet-type bleeding disorder 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566007	Vasculopathy, Retinal, With Cerebral Leukodystrophy	skos:exactMatch	doid	DOID:0111567	retinal vasculopathy with cerebral leukodystrophy	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C566029	Triosephosphate Isomerase Deficiency	skos:exactMatch	doid	0050884	triosephosphate isomerase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C566029	Triosephosphate Isomerase Deficiency	skos:exactMatch	doid	DOID:0050884	triosephosphate isomerase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C566039	Colorectal Cancer, Hereditary Nonpolyposis, Type 6	skos:exactMatch	doid	DOID:0070273	hereditary nonpolyposis colorectal cancer type 6	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566044	Cardiomyopathy, Familial Hypertrophic, 9	skos:exactMatch	doid	DOID:0110315	hypertrophic cardiomyopathy 9	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566108	Stormorken Syndrome	skos:exactMatch	doid	DOID:0060354	Stormorken syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4392,7 +4392,7 @@ mesh	C566815	Char syndrome	skos:exactMatch	doid	DOID:0060563	Char syndrome	manua
 mesh	C566822	Perry Syndrome	skos:exactMatch	doid	DOID:0060486	Perry syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566826	Parietal Foramina	skos:exactMatch	doid	DOID:0060285	parietal foramina	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566869	Night Blindness, Congenital Stationary, Autosomal Dominant 2	skos:exactMatch	doid	DOID:0110863	congenital stationary night blindness autosomal dominant 2	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C566906	Cakut	skos:exactMatch	doid	0080205	CAKUT	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C566906	Cakut	skos:exactMatch	doid	DOID:0080205	CAKUT	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C566912	Muscular Dystrophy, Limb-Girdle, Type 2M	skos:exactMatch	doid	DOID:0110296	autosomal recessive limb-girdle muscular dystrophy type 2M	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566916	Joubert Syndrome 7	skos:exactMatch	doid	DOID:0111002	Joubert syndrome 7	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C566925	Arrhythmogenic Right Ventricular Dysplasia, Familial, 12	skos:exactMatch	doid	DOID:0110083	arrhythmogenic right ventricular dysplasia 12	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4425,7 +4425,7 @@ mesh	C567084	Neuronopathy, Distal Hereditary Motor, Type IIB	skos:exactMatch	doi
 mesh	C567087	Brugada Syndrome 2	skos:exactMatch	doid	DOID:0110219	Brugada syndrome 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567090	Familial Cold Autoinflammatory Syndrome 2	skos:exactMatch	doid	DOID:0090063	familial cold autoinflammatory syndrome 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567098	Epilepsy, Familial Adult Myoclonic, 3	skos:exactMatch	doid	DOID:0111695	familial adult myoclonic epilepsy 3	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C567115	Combined Cellular And Humoral Immune Defects With Granulomas	skos:exactMatch	doid	0112253	combined cellular and humoral immune defects with granulomas	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C567115	Combined Cellular And Humoral Immune Defects With Granulomas	skos:exactMatch	doid	DOID:0112253	combined cellular and humoral immune defects with granulomas	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C567125	Combined Saposin Deficiency	skos:exactMatch	doid	DOID:0111330	combined saposin deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567126	Combined Oxidative Phosphorylation Deficiency 5	skos:exactMatch	doid	DOID:0111473	combined oxidative phosphorylation deficiency 5	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C567140	Bardet-Biedl Syndrome 13	skos:exactMatch	doid	DOID:0110135	Bardet-Biedl syndrome 13	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5069,7 +5069,7 @@ mesh	D000537	Aluminum Oxide	skos:exactMatch	chebi	CHEBI:30187	aluminium oxide	ma
 mesh	D000547	Amantadine	skos:exactMatch	chebi	CHEBI:2618	amantadine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000549	Ambenonium Chloride	skos:exactMatch	chebi	CHEBI:2628	ambenonium chloride	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D000551	Ambroxol	skos:exactMatch	chebi	CHEBI:135590	ambroxol	manually_reviewed	orcid:0000-0003-4423-4370
-mesh	D000564	Ameloblastoma	skos:exactMatch	doid	0050894	ameloblastoma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000564	Ameloblastoma	skos:exactMatch	doid	DOID:0050894	ameloblastoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000566	Amelogenesis	skos:exactMatch	go	GO:0097186	amelogenesis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000576	Americium	skos:exactMatch	chebi	CHEBI:33389	americium atom	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000583	Amikacin	skos:exactMatch	chebi	CHEBI:2637	amikacin	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5431,7 +5431,7 @@ mesh	D002748	Chlorpropham	skos:exactMatch	chebi	CHEBI:34630	chlorpropham	manuall
 mesh	D002784	Cholesterol	skos:exactMatch	chebi	CHEBI:16113	cholesterol	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002794	Choline	skos:exactMatch	chebi	CHEBI:15354	choline	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002801	Cholinesterase Reactivators	skos:exactMatch	chebi	CHEBI:50241	cholinesterase reactivator	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D002805	Chondrocalcinosis	skos:exactMatch	doid	1156	chondrocalcinosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002805	Chondrocalcinosis	skos:exactMatch	doid	DOID:1156	chondrocalcinosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D002819	Chorea	skos:exactMatch	doid	DOID:12859	choreatic disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D002821	Chorioamnionitis	skos:exactMatch	doid	DOID:0050697	chorioamnionitis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D002823	Chorion	skos:exactMatch	go	GO:0042600	chorion	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5569,7 +5569,7 @@ mesh	D005285	Fermentation	skos:exactMatch	go	GO:0006113	fermentation	manually_re
 mesh	D005306	Fertilization	skos:exactMatch	go	GO:0009566	fertilization	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005342	Fibrinolysis	skos:exactMatch	go	GO:0042730	fibrinolysis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005348	Fibrocystic Breast Disease	skos:exactMatch	doid	DOID:5998	microglandular adenosis	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	D005350	Fibroma	skos:exactMatch	doid	0050871	fibroma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005350	Fibroma	skos:exactMatch	doid	DOID:0050871	fibroma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005355	Fibrosis	skos:exactMatch	efo	0006890	fibrosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D005407	Flagella	skos:exactMatch	go	GO:0005929	cilium	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D005414	Flatulence	skos:exactMatch	efo	0009669	flatulence	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5652,7 +5652,7 @@ mesh	D006461	Hemolysis	skos:exactMatch	efo	0009473	hemolysis	manually_reviewed	o
 mesh	D006473	Postpartum Hemorrhage	skos:exactMatch	efo	0009579	postpartum hemorrhage	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006473	Postpartum Hemorrhage	skos:exactMatch	ncit	C92853	Postpartum Hemorrhage	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006487	Hemostasis	skos:exactMatch	go	GO:0007599	hemostasis	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D006504	Hepatic Veno-Occlusive Disease	skos:exactMatch	doid	0080177	hepatic veno-occlusive disease	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006504	Hepatic Veno-Occlusive Disease	skos:exactMatch	doid	DOID:0080177	hepatic veno-occlusive disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006550	Hernia, Femoral	skos:exactMatch	ncit	C34689	Femoral Hernia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006555	Hernia, Ventral	skos:exactMatch	ncit	C118313	Ventral Hernia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D006561	Herpes Simplex	skos:exactMatch	doid	DOID:8566	herpes simplex	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5802,7 +5802,7 @@ mesh	D009336	Necrosis	skos:exactMatch	efo	0009426	necrosis	manually_reviewed	orc
 mesh	D009336	Necrosis	skos:exactMatch	go	GO:0070265	necrotic cell death	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D009369	Neoplasms	skos:exactMatch	ncit	C23988	Neoplasms	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D009373	Neoplasms, Germ Cell and Embryonal	skos:exactMatch	doid	DOID:688	embryonal cancer	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	D009377	Multiple Endocrine Neoplasia	skos:exactMatch	doid	3125	multiple endocrine neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009377	Multiple Endocrine Neoplasia	skos:exactMatch	doid	DOID:3125	multiple endocrine neoplasia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D009411	Nerve Endings	skos:exactMatch	go	GO:0043679	axon terminus	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D009436	Neural Tube Defects	skos:exactMatch	doid	DOID:0080074	neural tube defect	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D009456	Neurofibromatosis 1	skos:exactMatch	doid	DOID:0111253	neurofibromatosis 1	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5825,12 +5825,12 @@ mesh	D010012	Osteogenesis	skos:exactMatch	go	GO:0001503	ossification	manually_re
 mesh	D010025	Osteoradionecrosis	skos:exactMatch	ncit	C63707	Osteoradionecrosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010032	Otitis Externa	skos:exactMatch	doid	DOID:9463	otitis externa	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010040	Otosclerosis	skos:exactMatch	doid	DOID:12185	otosclerosis	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	D010048	Ovarian Cysts	skos:exactMatch	doid	5119	ovarian cyst	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010048	Ovarian Cysts	skos:exactMatch	doid	DOID:5119	ovarian cyst	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010058	Oviposition	skos:exactMatch	go	GO:0018991	oviposition	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010060	Ovulation	skos:exactMatch	go	GO:0030728	ovulation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010064	Embryo Implantation	skos:exactMatch	go	GO:0007566	embryo implantation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010085	Oxidative Phosphorylation	skos:exactMatch	go	GO:0006119	oxidative phosphorylation	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D010144	Paget's Disease, Mammary	skos:exactMatch	doid	3443	mammary Paget's disease	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010144	Paget's Disease, Mammary	skos:exactMatch	doid	DOID:3443	mammary Paget's disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010178	Pancoast Syndrome	skos:exactMatch	doid	DOID:4876	trachea carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010182	Pancreatic Diseases	skos:exactMatch	doid	DOID:26	pancreas disease	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010252	Paramyxoviridae	skos:exactMatch	ncit	C14255	Paramyxoviridae	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5843,7 +5843,7 @@ mesh	D010409	Penile Diseases	skos:exactMatch	doid	DOID:1529	penile disease	manua
 mesh	D010410	Penile Erection	skos:exactMatch	go	GO:0043084	penile erection	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010427	Pentose Phosphate Pathway	skos:exactMatch	go	GO:0006098	pentose-phosphate shunt	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D010452	Peptide Biosynthesis	skos:exactMatch	go	GO:0043043	peptide biosynthetic process	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D010523	Peripheral Nervous System Diseases	skos:exactMatch	doid	574	peripheral nervous system disease	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010523	Peripheral Nervous System Diseases	skos:exactMatch	doid	DOID:574	peripheral nervous system disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010528	Peristalsis	skos:exactMatch	go	GO:0030432	peristalsis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D010554	Personality Disorders	skos:exactMatch	doid	DOID:1510	personality disorder	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D010587	Phagocytosis	skos:exactMatch	go	GO:0006909	phagocytosis	manually_reviewed	orcid:0000-0001-9439-5346
@@ -5888,7 +5888,7 @@ mesh	D011499	Protein Processing, Post-Translational	skos:exactMatch	go	GO:004368
 mesh	D011554	Pseudopodia	skos:exactMatch	go	GO:0031143	pseudopodium	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011588	Psychology, Educational	skos:exactMatch	ncit	C17030	Educational Psychology	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011618	Psychotic Disorders	skos:exactMatch	doid	DOID:2468	psychotic disorder	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	D011625	Pterygium	skos:exactMatch	doid	0002116	pterygium	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011625	Pterygium	skos:exactMatch	doid	DOID:0002116	pterygium	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011625	Pterygium	skos:exactMatch	doid	DOID:10526	conjunctival pterygium	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D011654	Pulmonary Edema	skos:exactMatch	ncit	C26868	Pulmonary Edema	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D011658	Pulmonary Fibrosis	skos:exactMatch	ncit	C26869	Pulmonary Fibrosis	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6188,12 +6188,12 @@ mesh	D017850	Economics, Pharmaceutical	skos:exactMatch	ncit	C142636	Pharmacoecon
 mesh	D017887	Ossification of Posterior Longitudinal Ligament	skos:exactMatch	efo	0005895	ossification of the posterior longitudinal ligament of the spine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018058	Tympanic Membrane Perforation	skos:exactMatch	efo	0009472	tympanic membrane perforation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018087	Plastids	skos:exactMatch	go	GO:0009536	plastid	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D018192	Lymphangioleiomyomatosis	skos:exactMatch	doid	3319	lymphangioleiomyomatosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018192	Lymphangioleiomyomatosis	skos:exactMatch	doid	DOID:3319	lymphangioleiomyomatosis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018253	Adenoma, Villous	skos:exactMatch	doid	DOID:0050869	villous adenoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018271	Signal Recognition Particle	skos:exactMatch	go	GO:0048500	signal recognition particle	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018275	Carcinoma, Lobular	skos:exactMatch	doid	DOID:0050938	breast lobular carcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018286	Carcinoma, Giant Cell	skos:exactMatch	ncit	C3779	Giant Cell Carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D018288	Carcinoma, Small Cell	skos:exactMatch	doid	0050685	small cell carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018288	Carcinoma, Small Cell	skos:exactMatch	doid	DOID:0050685	small cell carcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018293	Cystadenoma, Serous	skos:exactMatch	doid	DOID:5746	ovarian serous cystadenocarcinoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018295	Neoplasms, Basal Cell	skos:exactMatch	ncit	C3784	Basal Cell Neoplasm	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018308	Papilloma, Inverted	skos:exactMatch	ncit	C3793	Inverted Papilloma	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6279,7 +6279,7 @@ mesh	D020101	Acrosome Reaction	skos:exactMatch	go	GO:0007340	acrosome reaction	m
 mesh	D020160	Sodium Benzoate	skos:exactMatch	ncit	C66541	Sodium Benzoate	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D020169	Caspases	skos:exactMatch	ncit	C18153	Caspase	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D020170	Caspase 1	skos:exactMatch	hgnc	1499	CASP1	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D020176	Tyrosinemias	skos:exactMatch	doid	9275	tyrosinemia	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020176	Tyrosinemias	skos:exactMatch	doid	DOID:9275	tyrosinemia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D020219	Chondrogenesis	skos:exactMatch	go	GO:0051216	cartilage development	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D020237	Alexia, Pure	skos:exactMatch	doid	DOID:0060156	visual verbal agnosia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D020315	Latex Hypersensitivity	skos:exactMatch	doid	DOID:0060532	latex allergy	manually_reviewed	orcid:0000-0003-1307-2508
@@ -6431,7 +6431,7 @@ mesh	D052203	Ferrosoferric Oxide	skos:exactMatch	chebi	CHEBI:50821	ferrosoferric
 mesh	D052216	Glucagon-Like Peptide 1	skos:exactMatch	chebi	CHEBI:80270	Glucagon-like peptide 1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D052244	Endocrine Disruptors	skos:exactMatch	chebi	CHEBI:138015	endocrine disruptor	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D052578	Ionic Liquids	skos:exactMatch	chebi	CHEBI:63895	ionic liquid	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D052878	Urolithiasis	skos:exactMatch	doid	0080653	urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D052878	Urolithiasis	skos:exactMatch	doid	DOID:0080653	urolithiasis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D052998	Microcystins	skos:exactMatch	chebi	CHEBI:48041	microcystin	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D053038	Quorum Sensing	skos:exactMatch	go	GO:0009372	quorum sensing	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D053119	Benzophenanthridines	skos:exactMatch	chebi	CHEBI:38518	benzophenanthridine	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -3561,8 +3561,10 @@ mesh	C535955	Epidermolysa bullosa simplex and limb girdle muscular dystrophy	sko
 mesh	C535959	Epidermolysis bullosa simplex with mottled pigmentation	skos:exactMatch	doid	DOID:0111346	epidermolysis bullosa simplex with mottled pigmentation	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535971	Coloboma, cleft lip-palate and mental retardation syndrome	skos:exactMatch	doid	DOID:0111249	uveal coloboma-cleft lip and palate-intellectual disability	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535982	Congenital amegakaryocytic thrombocytopenia	skos:exactMatch	doid	DOID:0090118	congenital amegakaryocytic thrombocytopenia	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C535984	Congenital bilateral aplasia of vas deferens	skos:exactMatch	doid	DOID:0111862	congenital bilateral absence of vas deferens	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C535990	De Barsy syndrome	skos:exactMatch	doid	DOID:0070143	autosomal recessive cutis laxa type III	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C535998	Galactocele	skos:exactMatch	doid	DOID:10686	lactocele	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536008	Achalasia Addisonianism Alacrimia syndrome	skos:exactMatch	doid	DOID:0050602	triple-A syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536010	Achalasia microcephaly	skos:exactMatch	doid	DOID:0050796	achalasia microcephaly syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536012	Achard syndrome	skos:exactMatch	doid	DOID:6686	Achard syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536014	Acheiropodia	skos:exactMatch	doid	DOID:0050603	acheiropody	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3572,6 +3574,7 @@ mesh	C536026	Marshall-Smith syndrome	skos:exactMatch	doid	DOID:0050858	Marshall-
 mesh	C536028	Martsolf syndrome	skos:exactMatch	doid	DOID:0111586	Martsolf syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536029	MASA (Mental Retardation, Aphasia, Shuffling Gait, Adducted Thumbs) Syndrome	skos:exactMatch	doid	DOID:0060246	MASA syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536036	Maxillonasal dysplasia, Binder type	skos:exactMatch	doid	DOID:14683	Binder syndrome	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536038	Medium chain acyl CoA dehydrogenase deficiency	skos:exactMatch	doid	DOID:0080153	medium chain acyl-CoA dehydrogenase deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536039	Osteogenesis imperfecta, Levin type	skos:exactMatch	doid	DOID:0111533	gnathodiaphyseal dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536042	Osteogenesis imperfecta, type 2A	skos:exactMatch	doid	DOID:0110341	osteogenesis imperfecta type 2	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536050	Osteoglophonic dwarfism	skos:exactMatch	doid	DOID:0111532	osteoglophonic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3594,6 +3597,7 @@ mesh	C536156	Keratomalacia	skos:exactMatch	doid	DOID:11267	keratomalacia	manuall
 mesh	C536162	Keratosis palmoplantaris striata 1	skos:exactMatch	doid	DOID:0081108	keratosis palmoplantaris striata 1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536164	Keratosis palmoplantaris with esophageal cancer	skos:exactMatch	doid	DOID:0111506	palmoplantar keratoderma-esophageal carcinoma syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536166	Keshan disease	skos:exactMatch	doid	DOID:0050083	Keshan disease	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536169	Diaphyseal medullary stenosis with malignant fibrous histiocytoma	skos:exactMatch	doid	DOID:0080664	diaphyseal medullary stenosis with malignant fibrous histiocytoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536170	Diastrophic dysplasia	skos:exactMatch	doid	DOID:14687	diastrophic dysplasia	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536171	Dicarboxylicaminoaciduria	skos:exactMatch	doid	DOID:0060650	dicarboxylic aminoaciduria	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536173	Diffuse palmoplantar keratoderma, Bothnian type	skos:exactMatch	doid	DOID:0111707	Bothnian type palmoplantar keratoderma	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3720,8 +3724,8 @@ mesh	C536965	Tomaculous neuropathy	skos:exactMatch	doid	DOID:0060843	hereditary 
 mesh	C536969	Torsion dystonia with onset in infancy	skos:exactMatch	doid	DOID:0090058	torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C536974	Townes-Brocks syndrome	skos:exactMatch	doid	DOID:0050887	Townes-Brocks syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536979	Transient bullous dermolysis of the newborn	skos:exactMatch	doid	DOID:0111345	transient bullous dermolysis of the newborn	manually_reviewed	orcid:0000-0003-1307-2508
-mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	DOID:0080688	mosaic variegated aneuploidy syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	DOID:0080141	mosaic variegated aneuploidy syndrome 1	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C536987	Mosaic variegated aneuploidy syndrome	skos:exactMatch	doid	DOID:0080688	mosaic variegated aneuploidy syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C536990	Mowat-Wilson syndrome	skos:exactMatch	doid	DOID:0060485	Mowat-Wilson syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537005	Complement component 5 deficiency	skos:exactMatch	doid	DOID:8158	complement component 5 deficiency	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537013	Kaufman oculocerebrofacial syndrome	skos:exactMatch	doid	DOID:0111456	Kaufman oculocerebrofacial syndrome	manually_reviewed	orcid:0000-0003-1307-2508
@@ -3755,6 +3759,7 @@ mesh	C537133	Orofaciodigital syndrome 4	skos:exactMatch	doid	DOID:0060374	orofac
 mesh	C537135	Orofaciodigital syndrome, Shashi type	skos:exactMatch	doid	DOID:0060826	syndromic X-linked intellectual disability Shashi type	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537143	Ossification of the posterior longitudinal ligament of the spine	skos:exactMatch	efo	0005895	ossification of the posterior longitudinal ligament of the spine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537149	Hypogammaglobulinemia and Isolated growth hormone deficiency, X-linked	skos:exactMatch	doid	DOID:0060875	isolated growth hormone deficiency type III	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C537150	Hypoglycemia, leucine-induced	skos:exactMatch	doid	DOID:0112262	leucine-sensitive hypoglycemia of infancy	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537157	Hypoparathyroidism-retardation-dysmorphism syndrome	skos:exactMatch	doid	DOID:0060348	hypoparathyroidism-retardation-dysmorphism syndrome	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C537162	Pancreatoblastoma	skos:exactMatch	doid	DOID:6823	pancreatoblastoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C537172	Parastremmatic dwarfism	skos:exactMatch	doid	DOID:0111539	parastremmatic dwarfism	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4217,6 +4222,7 @@ mesh	C565070	Cleft Lip with or without Cleft Palate, Nonsyndromic, 8	skos:exactM
 mesh	C565079	Dyskeratosis Congenita, Autosomal Dominant	skos:exactMatch	doid	DOID:0070014	autosomal dominant dyskeratosis congenita 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565097	Digitotalar Dysmorphism	skos:exactMatch	doid	DOID:0111596	distal arthrogryposis type 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565100	Diabetes Mellitus, Insulin-Dependent, 2	skos:exactMatch	doid	DOID:0110741	type 1 diabetes mellitus 2	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	C565102	Keratosis Palmoplantaris Striata II	skos:exactMatch	doid	DOID:0081109	keratosis palmoplantaris striata 2	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	C565114	Failure of Tooth Eruption, Primary	skos:exactMatch	doid	DOID:0111341	primary failure of tooth eruption	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565121	Deafness, Autosomal Dominant 1	skos:exactMatch	doid	DOID:0110541	autosomal dominant nonsyndromic deafness 1	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	C565128	Mitochondrial Complex III Deficiency	skos:exactMatch	doid	DOID:0111139	mitochondrial complex III deficiency	manually_reviewed	orcid:0000-0003-1307-2508
@@ -4984,6 +4990,7 @@ mesh	D000080242	8-Hydroxy-2'-Deoxyguanosine	skos:exactMatch	chebi	CHEBI:40304	8-
 mesh	D000080282	Hormonal Contraception	skos:exactMatch	ncit	C92808	Hormonal Contraception	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000080309	Environmental DNA	skos:exactMatch	ncit	C169106	Environmental DNA	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000080345	Familial Exudative Vitreoretinopathies	skos:exactMatch	doid	DOID:0050535	exudative vitreoretinopathy	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D000080362	Stargardt Disease	skos:exactMatch	doid	DOID:0050817	Stargardt disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000080549	Autophagic Cell Death	skos:exactMatch	go	GO:0048102	autophagic cell death	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000080642	Chaperone-Mediated Autophagy	skos:exactMatch	go	GO:0061684	chaperone-mediated autophagy	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000080874	Synucleinopathies	skos:exactMatch	doid	DOID:0050890	synucleinopathy	manually_reviewed	orcid:0000-0003-1307-2508
@@ -5004,6 +5011,7 @@ mesh	D000105	Acetyl Coenzyme A	skos:exactMatch	chebi	CHEBI:15351	acetyl-CoA	manu
 mesh	D000109	Acetylcholine	skos:exactMatch	chebi	CHEBI:15355	acetylcholine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000114	Acetylene	skos:exactMatch	chebi	CHEBI:27518	acetylene	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000145	Acids, Aldehydic	skos:exactMatch	chebi	CHEBI:26643	aldehydic acid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000151	Acinetobacter Infections	skos:exactMatch	doid	DOID:3091	Acinetobacter infectious disease	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000156	Aconitic Acid	skos:exactMatch	chebi	CHEBI:22211	aconitic acid	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000157	Aconitine	skos:exactMatch	chebi	CHEBI:2430	aconitine	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D000165	Acridine Orange	skos:exactMatch	chebi	CHEBI:51739	acridine orange	manually_reviewed	orcid:0000-0001-9439-5346
@@ -6043,6 +6051,7 @@ mesh	D015266	Carcinoma, Merkel Cell	skos:exactMatch	doid	DOID:3965	Merkel cell c
 mesh	D015388	Organelles	skos:exactMatch	go	GO:0043226	organelle	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015398	Signal Transduction	skos:exactMatch	go	GO:0007165	signal transduction	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015467	Leukemia, Neutrophilic, Chronic	skos:exactMatch	doid	DOID:0080187	chronic neutrophilic leukemia	manually_reviewed	orcid:0000-0003-1307-2508
+mesh	D015477	Leukemia, Myelomonocytic, Chronic	skos:exactMatch	doid	DOID:0080188	chronic myelomonocytic leukemia	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015530	Nuclear Matrix	skos:exactMatch	go	GO:0016363	nuclear matrix	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015539	Platelet Activation	skos:exactMatch	go	GO:0030168	platelet activation	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D015636	Magnesium Chloride	skos:exactMatch	chebi	CHEBI:6636	magnesium dichloride	manually_reviewed	orcid:0000-0003-4423-4370
@@ -6205,6 +6214,7 @@ mesh	D018375	Neutrophil Activation	skos:exactMatch	go	GO:0042119	neutrophil acti
 mesh	D018385	Centrosome	skos:exactMatch	go	GO:0005813	centrosome	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018386	Kinetochores	skos:exactMatch	go	GO:0000776	kinetochore	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018392	Genomic Imprinting	skos:exactMatch	go	GO:0071514	genetic imprinting	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018442	Lymphoma, B-Cell, Marginal Zone	skos:exactMatch	doid	DOID:0050748	marginal zone B-cell lymphoma	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018442	Lymphoma, B-Cell, Marginal Zone	skos:exactMatch	doid	DOID:0050909	MALT lymphoma	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D018451	Homosexuality, Male	skos:exactMatch	efo	0008486	male homosexuality	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D018491	Dopamine Agonists	skos:exactMatch	chebi	CHEBI:51065	dopamine agonist	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2504,6 +2504,9 @@ doid	DOID:0050579	glycogen storage disease XV	skos:exactMatch	umls	C3150754	GLYC
 doid	DOID:0050585	congenital generalized lipodystrophy	skos:exactMatch	mesh	D052497	Lipodystrophy, Congenital Generalized	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050599	abdominal tuberculosis	skos:exactMatch	umls	C4087490	Abdominal tuberculosis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050608	Askin's tumor	skos:exactMatch	umls	C0877849	Askin's tumor	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0050634	alopecia universalis	skos:exactMatch	mesh	C537055	Alopecia universalis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0050678	Blau syndrome	skos:exactMatch	mesh	C538157	Blau syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0050679	blue cone monochromacy	skos:exactMatch	mesh	C536238	Blue cone monochromatism	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050696	fetal alcohol spectrum disorder	skos:exactMatch	mesh	D063647	Fetal Alcohol Spectrum Disorders	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050853	chronic venous insufficiency	skos:exactMatch	efo	0007940	chronic venous insufficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0050855	renal fibrosis	skos:exactMatch	umls	C0151650	Renal fibrosis	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2524,8 +2527,11 @@ doid	DOID:0060743	methylmalonic acidemia cblB type	skos:exactMatch	umls	C1855102
 doid	DOID:0060887	ossification of the posterior longitudinal ligament of spine	skos:exactMatch	mesh	C537143	Ossification of the posterior longitudinal ligament of the spine	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060887	ossification of the posterior longitudinal ligament of spine	skos:exactMatch	umls	C1865343	OSSIFICATION OF THE POSTERIOR LONGITUDINAL LIGAMENT OF SPINE	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070227	intrahepatic cholestasis of pregnancy	skos:exactMatch	efo	0009048	Intrahepatic cholestasis of pregnancy	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070296	primary autosomal recessive microcephaly	skos:exactMatch	mesh	C579935	Autosomal Recessive Primary Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0070306	post-cardiac arrest syndrome	skos:exactMatch	mesh	D000080942	Post-Cardiac Arrest Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070323	childhood acute myeloid leukemia	skos:exactMatch	efo	0000330	childhood acute myeloid leukemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070346	neurodevelopmental disorder with cataracts, poor growth, and dysmorphic facies	skos:exactMatch	efo	0010561	neurodevelopmental disorder with cataracts, poor growth, and dysmorphic facies	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:0080043	achondrogenesis	skos:exactMatch	mesh	C579878	Achondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	umls	C1302995	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080178	mucositis	skos:exactMatch	efo	1001898	mucositis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080322	polycystic kidney disease	skos:exactMatch	efo	0008620	Polycystic Kidney Disease	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2619,6 +2625,10 @@ doid	DOID:5767	hilar lung neoplasm	skos:exactMatch	umls	C1290358	Neoplasm of hil
 doid	DOID:62	aortic valve disease	skos:exactMatch	mesh	D000082862	Aortic Valve Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:6482	lung acinar adenocarcinoma	skos:exactMatch	umls	C1332137	Lung Acinar Adenocarcinoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:6590	spondylitis	skos:exactMatch	mesh	D013166	Spondylitis	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:7212	meningothelial meningioma	skos:exactMatch	efo	1000372	Meningothelial Meningioma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:7213	transitional meningioma	skos:exactMatch	efo	1000602	Transitional Meningioma	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:7363	vulvar keratinizing squamous cell carcinoma	skos:exactMatch	umls	C2109334	keratinizing squamous cell carcinoma of vulva	manually_reviewed	orcid:0000-0001-9439-5346
+doid	DOID:7664	endometrial mixed adenocarcinoma	skos:exactMatch	umls	C1516856	endometrial mixed adenocarcinoma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:7880	luteoma	skos:exactMatch	mesh	D018311	Luteoma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:8283	peritonitis	skos:exactMatch	mesh	D010538	Peritonitis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:83	cataract	skos:exactMatch	mesh	D002386	Cataract	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2516,92 +2516,42 @@ doid	DOID:0050986	spinocerebellar ataxia type 40	skos:exactMatch	efo	0009057	Spi
 doid	DOID:0060046	aphasia	skos:exactMatch	mesh	D001037	Aphasia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060077	progesterone-receptor positive breast cancer	skos:exactMatch	efo	0009782	progesterone-receptor positive breast cancer	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060098	osteoblastoma	skos:exactMatch	efo	1000410	Osteoblastoma	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060259	renal-hepatic-pancreatic dysplasia	skos:exactMatch	mesh	C567142	Renal-Hepatic-Pancreatic Dysplasia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060283	peeling skin syndrome	skos:exactMatch	mesh	C564818	Peeling Skin Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060297	complement component 4a deficiency	skos:exactMatch	mesh	C565167	Complement Component 4a Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060299	complement component 6 deficiency	skos:exactMatch	mesh	C567307	Complement Component 6 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060300	complement component 7 deficiency	skos:exactMatch	mesh	C566443	Complement Component 7 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060303	complement component 9 deficiency	skos:exactMatch	mesh	C565165	C9 Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060317	lung abscess	skos:exactMatch	mesh	D008169	Lung Abscess	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0060317	lung abscess	skos:exactMatch	umls	C0024110	Lung Abscess	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0060319	cardiac arrest	skos:exactMatch	efo	0009492	cardiac arrest	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060325	cervical polyp	skos:exactMatch	efo	0009475	cervical polyp	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060413	chromosome 22q11.2 deletion syndrome, distal	skos:exactMatch	mesh	C567511	Chromosome 22q11.2 Deletion Syndrome, Distal	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060415	chromosome 2p16.1-p15 deletion syndrome	skos:exactMatch	mesh	C567289	Chromosome 2p16.1-P15 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060416	chromosome 2q31.2 deletion syndrome	skos:exactMatch	mesh	C567344	Chromosome 2q31.2 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060422	chromosome 6pter-p24 deletion syndrome	skos:exactMatch	mesh	C567239	Chromosome 6pter-P24 Deletion Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060432	chromosome 17p13.3 duplication syndrome	skos:exactMatch	mesh	C567705	Chromosome 17p13.3 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060435	chromosome 1q21.1 duplication syndrome	skos:exactMatch	mesh	C567290	Chromosome 1q21.1 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060460	chromosome 5p13 duplication syndrome	skos:exactMatch	mesh	C567717	Chromosome 5p13 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060461	chromosome Xp11.23-p11.22 duplication syndrome	skos:exactMatch	mesh	C567585	Chromosome Xp11.23-P11.22 Duplication Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060538	purpura fulminans	skos:exactMatch	efo	1001913	Purpura Fulminans	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060540	Hermansky-Pudlak syndrome 2	skos:exactMatch	mesh	C537709	Hermansky Pudlak syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060564	spinal disease	skos:exactMatch	mesh	D013122	Spinal Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060580	Noonan syndrome 2	skos:exactMatch	mesh	C548081	Noonan Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060581	Noonan syndrome 3	skos:exactMatch	mesh	C537847	Noonan syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060582	Noonan syndrome 4	skos:exactMatch	mesh	C548082	Noonan Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060583	Noonan syndrome 5	skos:exactMatch	mesh	C548083	Noonan Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060584	Noonan syndrome 6	skos:exactMatch	mesh	C548084	Noonan Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060602	alpha-methylacyl-CoA racemase deficiency	skos:exactMatch	mesh	C565768	Alpha-Methylacyl-CoA Racemase Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060604	ankyloglossia	skos:exactMatch	mesh	D000072676	Ankyloglossia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060609	microcephalic osteodysplastic primordial dwarfism type II	skos:exactMatch	mesh	C565898	Microcephalic Osteodysplastic Primordial Dwarfism, Type II	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060611	abdominal obesity-metabolic syndrome	skos:exactMatch	mesh	C535554	Abdominal obesity metabolic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060611	abdominal obesity-metabolic syndrome	skos:exactMatch	umls	C2930930	Abdominal obesity metabolic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060612	abdominal obesity-metabolic syndrome 3	skos:exactMatch	umls	C4014361	ABDOMINAL OBESITY-METABOLIC SYNDROME 3	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060668	anencephaly	skos:exactMatch	mesh	D000757	Anencephaly	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060743	methylmalonic acidemia cblB type	skos:exactMatch	mesh	C537361	Methylmalonic aciduria cblB type	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060743	methylmalonic acidemia cblB type	skos:exactMatch	umls	C1855102	Methylmalonic aciduria cblB type	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060746	basal laminar drusen	skos:exactMatch	mesh	C563034	Basal Laminar Drusen	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060769	T-cell immunodeficiency, congenital alopecia, and nail dystrophy	skos:exactMatch	mesh	C536781	T-cell immunodeficiency, congenital alopecia and nail dystrophy	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0060858	hypotonia-cystinuria syndrome	skos:exactMatch	mesh	C564710	Hypotonia-Cystinuria Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060887	ossification of the posterior longitudinal ligament of spine	skos:exactMatch	mesh	C537143	Ossification of the posterior longitudinal ligament of the spine	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0060887	ossification of the posterior longitudinal ligament of spine	skos:exactMatch	umls	C1865343	OSSIFICATION OF THE POSTERIOR LONGITUDINAL LIGAMENT OF SPINE	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0070007	Seckel syndrome 1	skos:exactMatch	mesh	C537533	Seckel syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0070013	Seckel syndrome 2	skos:exactMatch	mesh	C537534	Seckel syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0070096	oculocutaneous albinism type II	skos:exactMatch	mesh	C537730	Oculocutaneous albinism type 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070227	intrahepatic cholestasis of pregnancy	skos:exactMatch	efo	0009048	Intrahepatic cholestasis of pregnancy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070296	primary autosomal recessive microcephaly	skos:exactMatch	mesh	C579935	Autosomal Recessive Primary Microcephaly	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070306	post-cardiac arrest syndrome	skos:exactMatch	mesh	D000080942	Post-Cardiac Arrest Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070323	childhood acute myeloid leukemia	skos:exactMatch	efo	0000330	childhood acute myeloid leukemia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0070344	ocular tuberculosis	skos:exactMatch	mesh	D014392	Tuberculosis, Ocular	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0070346	neurodevelopmental disorder with cataracts, poor growth, and dysmorphic facies	skos:exactMatch	efo	0010561	neurodevelopmental disorder with cataracts, poor growth, and dysmorphic facies	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080039	axial osteomalacia	skos:exactMatch	mesh	C537791	Axial osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080043	achondrogenesis	skos:exactMatch	mesh	C579878	Achondrogenesis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080056	achondrogenesis type II	skos:exactMatch	mesh	C536017	Achondrogenesis type 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080074	neural tube defect	skos:exactMatch	mesh	D009436	Neural Tube Defects	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080091	spheroid body myopathy	skos:exactMatch	mesh	C000598645	Spheroid body myopathy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	mesh	C580012	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080143	congenital fibrosis of the extraocular muscles	skos:exactMatch	umls	C1302995	Congenital Fibrosis of the Extraocular Muscles	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080178	mucositis	skos:exactMatch	efo	1001898	mucositis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080187	chronic neutrophilic leukemia	skos:exactMatch	mesh	D015467	Leukemia, Neutrophilic, Chronic	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080234	Clark-Baraitser syndrome	skos:exactMatch	mesh	C536208	Clark-Baraitser syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080322	polycystic kidney disease	skos:exactMatch	efo	0008620	Polycystic Kidney Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080324	tuberous sclerosis 1	skos:exactMatch	mesh	C565346	Tuberous Sclerosis 1	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080325	tuberous sclerosis 2	skos:exactMatch	mesh	C566021	Tuberous Sclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080332	bicuspid aortic valve disease	skos:exactMatch	mesh	D000082882	Bicuspid Aortic Valve Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080344	blepharocheilodontic syndrome	skos:exactMatch	mesh	C536188	Blepharo-cheilo-dontic syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080356	IgG4-related disease	skos:exactMatch	mesh	D000077733	Immunoglobulin G4-Related Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080395	orofacial cleft 1	skos:exactMatch	mesh	C566121	Orofacial Cleft 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080396	orofacial cleft 2	skos:exactMatch	mesh	C566419	Orofacial Cleft 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080397	orofacial cleft 3	skos:exactMatch	mesh	C563448	Orofacial Cleft 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080398	orofacial cleft 4	skos:exactMatch	mesh	C564251	Orofacial Cleft 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080399	orofacial cleft 5	skos:exactMatch	mesh	C563843	Orofacial Cleft 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080402	orofacial cleft 9	skos:exactMatch	mesh	C563675	Orofacial Cleft 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080403	orofacial cleft 10	skos:exactMatch	mesh	C566605	Orofacial Cleft 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080404	orofacial cleft 11	skos:exactMatch	mesh	C567410	Orofacial Cleft 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080405	orofacial cleft 12	skos:exactMatch	mesh	C567548	Orofacial Cleft 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080494	ovarian dysgenesis 2	skos:exactMatch	mesh	C564499	Ovarian Dysgenesis 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080531	dedifferentiated liposarcoma	skos:exactMatch	efo	0003085	dedifferentiated liposarcoma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080533	Carney-Stratakis syndrome	skos:exactMatch	mesh	C564650	Carney-Stratakis Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080539	PEHO syndrome	skos:exactMatch	mesh	C536317	PEHO syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080543	hyperprolinemia type 2	skos:exactMatch	mesh	C538385	Hyperprolinemia type 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080546	non-alcoholic fatty liver	skos:exactMatch	efo	1001248	non-alcoholic fatty liver	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080547	non-alcoholic steatohepatitis	skos:exactMatch	efo	1001249	non-alcoholic steatohepatitis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080551	Naxos disease	skos:exactMatch	mesh	C538346	Naxos disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080576	spondyloepimetaphyseal dysplasia, Genevieve-type	skos:exactMatch	mesh	C535785	Spondyloepimetaphyseal dysplasia, Genevieve type	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080580	3-Methylcrotonyl-CoA carboxylase 2 deficiency	skos:exactMatch	mesh	C535309	3-methylcrotonyl CoA carboxylase 2 deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080583	Wolfram syndrome, mitochondrial form	skos:exactMatch	mesh	C564012	Wolfram Syndrome, Mitochondrial Form	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0080666	warfarin sensitivity	skos:exactMatch	mesh	C567080	Warfarin Sensitivity	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080678	mucolipidosis III gamma	skos:exactMatch	mesh	C565367	Mucolipidosis III Gamma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080690	RASopathy	skos:exactMatch	efo	1001502	rasopathy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0080695	Burn-McKeown syndrome	skos:exactMatch	mesh	C537411	Burn-Mckeown syndrome	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2662,194 +2612,37 @@ doid	DOID:0081044	frontonasal dysplasia	skos:exactMatch	mesh	C538065	Frontonasal
 doid	DOID:0081057	gestational diabetes insipidus	skos:exactMatch	mesh	C548014	Gestational Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0081058	dipsogenic diabetes insipidus	skos:exactMatch	mesh	C548013	Dipsogenic Diabetes Insipidus	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0081082	acute myelomonocytic leukemia	skos:exactMatch	mesh	D015479	Leukemia, Myelomonocytic, Acute	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0090002	Tietz syndrome	skos:exactMatch	mesh	C536919	Tietz syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0090033	myoclonic dystonia	skos:exactMatch	mesh	C536096	Myoclonic dystonia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0090048	dystonia 16	skos:exactMatch	mesh	C567430	Dystonia 16	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0090056	dystonia 12	skos:exactMatch	mesh	C538001	Dystonia 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0090058	torsion dystonia with onset in infancy	skos:exactMatch	mesh	C536969	Torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0090066	Fanconi-like syndrome	skos:exactMatch	mesh	C536855	Fanconi like syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0090113	RIDDLE syndrome	skos:exactMatch	efo	0009055	RIDDLE syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0090130	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110006	3-methylglutaconic aciduria type 4	skos:exactMatch	mesh	C565393	3-Methylglutaconic Aciduria Type IV	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110007	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110008	achromatopsia 3	skos:exactMatch	mesh	C536129	Achromatopsia 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110010	achromatopsia 4	skos:exactMatch	mesh	C564206	Achromatopsia 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110016	Leber congenital amaurosis 2	skos:exactMatch	mesh	C536601	Amaurosis congenita of Leber, type 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110078	Leber congenital amaurosis 1	skos:exactMatch	mesh	C536600	Amaurosis congenita of Leber, type 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110080	Leber congenital amaurosis 12	skos:exactMatch	mesh	C565697	Leber Congenital Amaurosis 12	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110085	asphyxiating thoracic dystrophy 1	skos:exactMatch	umls	C4551856	Asphyxiating Thoracic Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110086	asphyxiating thoracic dystrophy 2	skos:exactMatch	mesh	C566982	Asphyxiating Thoracic Dystrophy 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110086	asphyxiating thoracic dystrophy 2	skos:exactMatch	umls	C1970005	Asphyxiating Thoracic Dystrophy 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110123	Bardet-Biedl syndrome 1	skos:exactMatch	efo	0009021	Bardet-Biedl syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110123	Bardet-Biedl syndrome 1	skos:exactMatch	mesh	C537909	Bardet-Biedl syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110124	Bardet-Biedl syndrome 2	skos:exactMatch	mesh	C537910	Bardet-Biedl syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110125	Bardet-Biedl syndrome 3	skos:exactMatch	mesh	C537911	Bardet-Biedl syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110126	Bardet-Biedl syndrome 4	skos:exactMatch	efo	0009024	Bardet-Biedl syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110126	Bardet-Biedl syndrome 4	skos:exactMatch	mesh	C537912	Bardet-Biedl syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110127	Bardet-Biedl syndrome 5	skos:exactMatch	efo	0009025	Bardet-Biedl syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110128	Bardet-Biedl syndrome 6	skos:exactMatch	mesh	C565738	Bardet-Biedl Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110129	Bardet-Biedl syndrome 7	skos:exactMatch	efo	0009026	Bardet-Biedl syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110129	Bardet-Biedl syndrome 7	skos:exactMatch	mesh	C565916	Bardet-Biedl Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110130	Bardet-Biedl syndrome 8	skos:exactMatch	mesh	C565917	Bardet-Biedl Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110131	Bardet-Biedl syndrome 9	skos:exactMatch	efo	0009027	Bardet-Biedl syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110131	Bardet-Biedl syndrome 9	skos:exactMatch	mesh	C565918	Bardet-Biedl Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110132	Bardet-Biedl syndrome 10	skos:exactMatch	efo	0009022	Bardet-Biedl syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110132	Bardet-Biedl syndrome 10	skos:exactMatch	mesh	C565919	Bardet-Biedl Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110133	Bardet-Biedl syndrome 11	skos:exactMatch	mesh	C565920	Bardet-Biedl Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110134	Bardet-Biedl syndrome 12	skos:exactMatch	efo	0009023	Bardet-Biedl syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110134	Bardet-Biedl syndrome 12	skos:exactMatch	mesh	C565921	Bardet-Biedl Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110135	Bardet-Biedl syndrome 13	skos:exactMatch	mesh	C567140	Bardet-Biedl Syndrome 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110136	Bardet-Biedl syndrome 14	skos:exactMatch	mesh	C567141	Bardet-Biedl Syndrome 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110188	Leber congenital amaurosis 14	skos:exactMatch	mesh	C567636	Leber Congenital Amaurosis 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110214	cleft soft palate	skos:exactMatch	mesh	C562950	Cleft Soft Palate	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110215	Leber congenital amaurosis 5	skos:exactMatch	mesh	C536602	Amaurosis congenita of Leber, type 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110216	Leber congenital amaurosis 11	skos:exactMatch	mesh	C564140	Leber Congenital Amaurosis 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110219	Brugada syndrome 2	skos:exactMatch	mesh	C567087	Brugada Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110220	Brugada syndrome 3	skos:exactMatch	mesh	C567509	Brugada Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110221	Brugada syndrome 4	skos:exactMatch	mesh	C567508	Brugada Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110222	Brugada syndrome 5	skos:exactMatch	mesh	C567556	Brugada Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110223	Brugada syndrome 6	skos:exactMatch	mesh	C567735	Brugada Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110224	Brugada syndrome 7	skos:exactMatch	mesh	C567734	Brugada Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110225	Brugada syndrome 8	skos:exactMatch	mesh	C567732	Brugada Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110291	Leber congenital amaurosis 10	skos:exactMatch	mesh	C565720	Leber Congenital Amaurosis 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110329	Leber congenital amaurosis 6	skos:exactMatch	mesh	C565327	Leber Congenital Amaurosis 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110330	Leber congenital amaurosis 13	skos:exactMatch	mesh	C567197	Leber Congenital Amaurosis 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110331	Leber congenital amaurosis 3	skos:exactMatch	mesh	C565814	Leber Congenital Amaurosis 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110332	Leber congenital amaurosis 4	skos:exactMatch	mesh	C565778	Leber Congenital Amaurosis 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110337	osteogenesis imperfecta type 7	skos:exactMatch	mesh	C565200	Osteogenesis Imperfecta Type VII	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110353	retinitis pigmentosa 20	skos:exactMatch	mesh	C566718	Retinitis Pigmentosa 20	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110354	retinitis pigmentosa 19	skos:exactMatch	mesh	C566637	Retinitis Pigmentosa 19	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110355	retinitis pigmentosa 32	skos:exactMatch	mesh	C563689	Retinitis Pigmentosa 32	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110356	retinitis pigmentosa 18	skos:exactMatch	mesh	C563320	Retinitis Pigmentosa 18	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110357	retinitis pigmentosa 35	skos:exactMatch	mesh	C565206	Retinitis Pigmentosa 35	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110358	retinitis pigmentosa 12	skos:exactMatch	mesh	C563999	Retinitis Pigmentosa 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110366	retinitis pigmentosa 33	skos:exactMatch	mesh	C563676	Retinitis Pigmentosa 33	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110368	retinitis pigmentosa 26	skos:exactMatch	mesh	C564249	Retinitis Pigmentosa 26	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110376	retinitis pigmentosa 41	skos:exactMatch	mesh	C567422	Retinitis Pigmentosa 41	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110378	retinitis pigmentosa 29	skos:exactMatch	mesh	C567403	Retinitis Pigmentosa 29	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110381	retinitis pigmentosa 14	skos:exactMatch	mesh	C563992	Retinitis Pigmentosa 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110383	retinitis pigmentosa 7	skos:exactMatch	mesh	C564284	Retinitis Pigmentosa 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110384	retinitis pigmentosa 25	skos:exactMatch	mesh	C566425	Retinitis Pigmentosa 25	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110386	retinitis pigmentosa 42	skos:exactMatch	mesh	C567854	Retinitis Pigmentosa 42	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110387	retinitis pigmentosa 9	skos:exactMatch	mesh	C566716	Retinitis Pigmentosa 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110388	retinitis pigmentosa 10	skos:exactMatch	mesh	C566715	Retinitis Pigmentosa 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110391	retinitis pigmentosa 31	skos:exactMatch	mesh	C563685	Retinitis Pigmentosa 31	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110397	retinitis pigmentosa 27	skos:exactMatch	mesh	C563526	Retinitis Pigmentosa 27	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110399	retinitis pigmentosa 37	skos:exactMatch	mesh	C567005	Retinitis Pigmentosa 37	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110403	retinitis pigmentosa 13	skos:exactMatch	mesh	C564008	Retinitis Pigmentosa 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110404	retinitis pigmentosa 17	skos:exactMatch	mesh	C563437	Retinitis Pigmentosa 17	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110405	retinitis pigmentosa 36	skos:exactMatch	mesh	C566431	Retinitis Pigmentosa 36	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110406	retinitis pigmentosa 30	skos:exactMatch	mesh	C564310	Retinitis Pigmentosa 30	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110408	retinitis pigmentosa 11	skos:exactMatch	mesh	C563991	Retinitis Pigmentosa 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110409	retinitis pigmentosa 46	skos:exactMatch	mesh	C567249	Retinitis Pigmentosa 46	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110413	retinitis pigmentosa 6	skos:exactMatch	mesh	C564065	Retinitis Pigmentosa 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110414	retinitis pigmentosa 3	skos:exactMatch	mesh	C564520	Retinitis Pigmentosa 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110415	retinitis pigmentosa 2	skos:exactMatch	mesh	C567523	Retinitis Pigmentosa 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110417	retinitis pigmentosa 34	skos:exactMatch	mesh	C564475	Retinitis Pigmentosa 34	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110630	Wolfram syndrome 2	skos:exactMatch	mesh	C565733	Wolfram Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110645	long QT syndrome 2	skos:exactMatch	mesh	C563614	Long Qt Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110646	long QT syndrome 3	skos:exactMatch	mesh	C565840	Long Qt Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110647	long QT syndrome 5	skos:exactMatch	mesh	C566766	Long Qt Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110648	long QT syndrome 6	skos:exactMatch	mesh	C566333	Long Qt Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110650	long QT syndrome 9	skos:exactMatch	mesh	C567515	Long Qt Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110651	long QT syndrome 10	skos:exactMatch	mesh	C567514	Long Qt Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110652	long QT syndrome 11	skos:exactMatch	mesh	C567513	Long Qt Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110653	long QT syndrome 12	skos:exactMatch	mesh	C567842	Long Qt Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110702	hypotrichosis 5	skos:exactMatch	mesh	C567554	Hypotrichosis 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110736	neurodegeneration with brain iron accumulation 2b	skos:exactMatch	mesh	C565699	NBIA2B	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110872	holoprosencephaly 2	skos:exactMatch	mesh	C563579	Holoprosencephaly 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110873	holoprosencephaly 9	skos:exactMatch	mesh	C563659	Holoprosencephaly 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110874	holoprosencephaly 6	skos:exactMatch	mesh	C565274	Holoprosencephaly 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110875	holoprosencephaly 3	skos:exactMatch	mesh	C564181	Holoprosencephaly 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110876	holoprosencephaly 7	skos:exactMatch	mesh	C563660	Holoprosencephaly 7	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110878	holoprosencephaly 5	skos:exactMatch	mesh	C566464	Holoprosencephaly 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110879	holoprosencephaly 8	skos:exactMatch	mesh	C563723	Holoprosencephaly 8	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110880	holoprosencephaly 4	skos:exactMatch	mesh	C564180	Holoprosencephaly 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110882	inflammatory bowel disease 7	skos:exactMatch	mesh	C565353	Inflammatory Bowel Disease 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110883	inflammatory bowel disease 17	skos:exactMatch	mesh	C567378	Inflammatory Bowel Disease 17	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110884	inflammatory bowel disease 23	skos:exactMatch	mesh	C567326	Inflammatory Bowel Disease 23	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110885	inflammatory bowel disease 10	skos:exactMatch	mesh	C567021	Inflammatory Bowel Disease 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110886	inflammatory bowel disease 9	skos:exactMatch	mesh	C563926	Inflammatory Bowel Disease 9	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110887	inflammatory bowel disease 12	skos:exactMatch	mesh	C567388	Inflammatory Bowel Disease 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110888	inflammatory bowel disease 18	skos:exactMatch	mesh	C567377	Inflammatory Bowel Disease 18	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110889	inflammatory bowel disease 5	skos:exactMatch	mesh	C565234	Inflammatory Bowel Disease 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110890	inflammatory bowel disease 19	skos:exactMatch	mesh	C567372	Inflammatory Bowel Disease 19	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110891	inflammatory bowel disease 3	skos:exactMatch	mesh	C565764	Inflammatory Bowel Disease 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110893	inflammatory bowel disease 13	skos:exactMatch	mesh	C567384	Inflammatory Bowel Disease 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110894	inflammatory bowel disease 11	skos:exactMatch	mesh	C567154	Inflammatory Bowel Disease 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110895	inflammatory bowel disease 14	skos:exactMatch	mesh	C567383	Inflammatory Bowel Disease 14	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110896	inflammatory bowel disease 16	skos:exactMatch	mesh	C567380	Inflammatory Bowel Disease 16	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110897	inflammatory bowel disease 15	skos:exactMatch	mesh	C567381	Inflammatory Bowel Disease 15	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110898	inflammatory bowel disease 20	skos:exactMatch	mesh	C567361	Inflammatory Bowel Disease 20	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110900	inflammatory bowel disease 2	skos:exactMatch	mesh	C563310	Inflammatory Bowel Disease 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110901	inflammatory bowel disease 26	skos:exactMatch	mesh	C567217	Inflammatory Bowel Disease 26	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110902	inflammatory bowel disease 27	skos:exactMatch	mesh	C567559	Inflammatory Bowel Disease 27	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110903	inflammatory bowel disease 4	skos:exactMatch	mesh	C564680	Inflammatory Bowel Disease 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110904	inflammatory bowel disease 8	skos:exactMatch	mesh	C564682	Inflammatory Bowel Disease 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110905	inflammatory bowel disease 22	skos:exactMatch	mesh	C567327	Inflammatory Bowel Disease 22	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110906	inflammatory bowel disease 21	skos:exactMatch	mesh	C567338	Inflammatory Bowel Disease 21	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110907	inflammatory bowel disease 6	skos:exactMatch	mesh	C564681	Inflammatory Bowel Disease 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110908	inflammatory bowel disease 24	skos:exactMatch	mesh	C567252	Inflammatory Bowel Disease 24	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110912	leukocyte adhesion deficiency 3	skos:exactMatch	mesh	C567555	Leukocyte Adhesion Deficiency, Type III	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110926	nemaline myopathy 1	skos:exactMatch	mesh	C538348	Nemaline myopathy 1	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0110928	nemaline myopathy 2	skos:exactMatch	mesh	C538349	Nemaline Myopathy 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110932	nemaline myopathy 4	skos:exactMatch	mesh	C538351	Nemaline myopathy 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110934	nemaline myopathy 7	skos:exactMatch	mesh	C565198	Nemaline Myopathy 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110935	nemaline myopathy 6	skos:exactMatch	mesh	C538398	Nemaline myopathy 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110936	nemaline myopathy 5	skos:exactMatch	mesh	C538397	Nemaline myopathy 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110947	Waardenburg syndrome type 2B	skos:exactMatch	mesh	C536465	Waardenburg syndrome type 2B	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110950	Waardenburg syndrome type 2A	skos:exactMatch	mesh	C536464	Waardenburg syndrome type 2A	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110964	brachydactyly type A1	skos:exactMatch	mesh	C537088	Brachydactyly type A1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0110966	brachydactyly type A3	skos:exactMatch	mesh	C537090	Brachydactyly type A3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111009	cone-rod dystrophy 1	skos:exactMatch	mesh	C563469	Cone-Rod Dystrophy 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111010	cone-rod dystrophy 5	skos:exactMatch	mesh	C563415	Cone-Rod Dystrophy 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111012	cone-rod dystrophy 7	skos:exactMatch	mesh	C566350	Cone-Rod Dystrophy 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111013	cone-rod dystrophy 3	skos:exactMatch	mesh	C565827	Cone-Rod Dystrophy 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111014	cone-rod dystrophy 8	skos:exactMatch	mesh	C565322	Cone-Rod Dystrophy 8	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111016	cone-rod dystrophy 13	skos:exactMatch	mesh	C567698	Cone-Rod Dystrophy 13	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111017	cone-rod dystrophy 10	skos:exactMatch	mesh	C564597	Cone-Rod Dystrophy 10	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111018	cone-rod dystrophy 11	skos:exactMatch	mesh	C563671	Cone-Rod Dystrophy 11	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111019	cone-rod dystrophy 12	skos:exactMatch	mesh	C567206	Cone-Rod Dystrophy 12	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111041	glycogen storage disease IXb	skos:exactMatch	mesh	C563008	Glycogen Storage Disease IXB	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111043	glycogen storage disease IXc	skos:exactMatch	mesh	C567809	Glycogen Storage Disease IXC	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111079	birdshot chorioretinopathy	skos:exactMatch	mesh	D000080365	Birdshot Chorioretinopathy	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0111079	birdshot chorioretinopathy	skos:exactMatch	umls	C1853959	Birdshot Chorioretinopathy	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0111086	Fanconi anemia complementation group G	skos:exactMatch	efo	0009046	Fanconi anemia complementation group G	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111088	Fanconi anemia complementation group F	skos:exactMatch	efo	0009045	Fanconi anemia complementation group F	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111095	Fanconi anemia complementation group A	skos:exactMatch	efo	0009044	Fanconi anemia complementation group A	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111113	nephronophthisis 2	skos:exactMatch	mesh	C566582	Nephronophthisis 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111114	nephronophthisis 3	skos:exactMatch	mesh	C565780	Nephronophthisis 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111115	nephronophthisis 4	skos:exactMatch	mesh	C564640	Nephronophthisis 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111116	nephronophthisis 7	skos:exactMatch	mesh	C566930	Nephronophthisis 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111129	focal segmental glomerulosclerosis 2	skos:exactMatch	mesh	C565831	Focal Segmental Glomerulosclerosis 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111130	focal segmental glomerulosclerosis 5	skos:exactMatch	mesh	C567687	Focal Segmental Glomerulosclerosis 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111139	mitochondrial complex III deficiency	skos:exactMatch	mesh	C565128	Mitochondrial Complex III Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111144	preterm premature rupture of the membranes	skos:exactMatch	mesh	C563032	Preterm Premature Rupture of the Membranes	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111162	epidermal nevus	skos:exactMatch	mesh	C580062	Epidermal Nevus	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111165	molybdenum cofactor deficiency	skos:exactMatch	mesh	C535811	Molybdenum cofactor deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111167	Dyggve-Melchior-Clausen disease	skos:exactMatch	mesh	C535726	Dyggve-Melchior-Clausen syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111218	Friedreich ataxia 1	skos:exactMatch	mesh	C565561	Friedreich Ataxia 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111219	Friedreich ataxia 2	skos:exactMatch	mesh	C566594	Friedreich Ataxia 2	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111227	chromosome 3-linked frontotemporal dementia	skos:exactMatch	mesh	C579991	Chromosome 3-Linked Frontotemporal Dementia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111330	combined saposin deficiency	skos:exactMatch	mesh	C567125	Combined Saposin Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111347	epidermolysis bullosa with congenital localized absence of skin and deformity of nails	skos:exactMatch	mesh	C562638	Epidermolysis Bullosa With Congenital Localized Absence Of Skin And Deformity Of Nails	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111355	hydrolethalus syndrome 1	skos:exactMatch	mesh	C565504	Hydrolethalus Syndrome 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111370	apolipoprotein C-III deficiency	skos:exactMatch	mesh	C566270	Apolipoprotein C-III Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111408	exudative vitreoretinopathy 5	skos:exactMatch	mesh	C567648	Exudative Vitreoretinopathy 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111409	exudative vitreoretinopathy 3	skos:exactMatch	mesh	C565297	Exudative Vitreoretinopathy 3	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111411	exudative vitreoretinopathy 4	skos:exactMatch	mesh	C566619	Exudative Vitreoretinopathy 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111412	exudative vitreoretinopathy 1	skos:exactMatch	mesh	C536382	Exudative vitreoretinopathy 1	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111435	optic atrophy 6	skos:exactMatch	mesh	C537127	Optic atrophy 6	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111437	optic atrophy 7	skos:exactMatch	mesh	C567833	Optic Atrophy 7	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111438	optic atrophy 5	skos:exactMatch	mesh	C537126	Optic atrophy 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111440	optic atrophy 4	skos:exactMatch	mesh	C565343	Optic Atrophy 4	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111473	combined oxidative phosphorylation deficiency 5	skos:exactMatch	mesh	C567126	Combined Oxidative Phosphorylation Deficiency 5	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111483	combined oxidative phosphorylation deficiency 2	skos:exactMatch	mesh	C566468	Combined Oxidative Phosphorylation Deficiency 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111495	combined oxidative phosphorylation deficiency 33	skos:exactMatch	efo	0009159	combined oxidative phosphorylation deficiency 33	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111504	Li-Fraumeni syndrome 2	skos:exactMatch	mesh	C563755	Li-Fraumeni Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111552	scapuloperoneal spinal muscular atrophy	skos:exactMatch	efo	1001992	Scapuloperoneal spinal muscular atrophy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111560	Charcot-Marie-Tooth disease type 1G	skos:exactMatch	efo	0010266	Charcot-Marie-Tooth disease type 1G	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:0111701	long QT syndrome 4	skos:exactMatch	mesh	C563428	Long Qt Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111771	46,XY sex reversal 4	skos:exactMatch	mesh	C567887	46,XY Sex Reversal 4	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111820	zygodactyly 1	skos:exactMatch	mesh	C565223	Zygodactyly 1	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0111841	Shukla-Vernon syndrome	skos:exactMatch	efo	0010278	Shukla-Vernon syndrome	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2874,21 +2667,15 @@ doid	DOID:0112328	pontocerebellar hypoplasia type 2	skos:exactMatch	mesh	C548070
 doid	DOID:10032	hyperlucent lung	skos:exactMatch	mesh	D019568	Lung, Hyperlucent	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:10032	hyperlucent lung	skos:exactMatch	umls	C0524799	Lung, Hyperlucent	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:1019	osteomyelitis	skos:exactMatch	mesh	D010019	Osteomyelitis	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:10247	pleurisy	skos:exactMatch	mesh	D010998	Pleurisy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:10573	osteomalacia	skos:exactMatch	efo	1002027	osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:10573	osteomalacia	skos:exactMatch	mesh	D010018	Osteomalacia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1059	intellectual disability	skos:exactMatch	mesh	D008607	Intellectual Disability	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:10854	salivary gland disease	skos:exactMatch	mesh	D012466	Salivary Gland Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:1088	meningocele	skos:exactMatch	mesh	D008588	Meningocele	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:11263	chlamydia	skos:exactMatch	mesh	D002689	Chlamydia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:11294	arteriovenous malformation	skos:exactMatch	mesh	D001165	Arteriovenous Malformations	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:11613	hyperandrogenism	skos:exactMatch	efo	0009006	hyperandrogenism	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:11758	iron deficiency anemia	skos:exactMatch	mesh	D018798	Anemia, Iron-Deficiency	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:11917	tinea cruris	skos:exactMatch	mesh	D000084002	Tinea cruris	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:12140	Chagas disease	skos:exactMatch	mesh	D014355	Chagas Disease	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:12351	alcoholic hepatitis	skos:exactMatch	mesh	D006519	Hepatitis, Alcoholic	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1307	dementia	skos:exactMatch	mesh	D003704	Dementia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:13403	neurosarcoidosis	skos:exactMatch	mesh	C535814	Neurosarcoidosis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1373	endometrial stromal nodule	skos:exactMatch	efo	1000241	Endometrial Stromal Nodule	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:13891	bird fancier's lung	skos:exactMatch	mesh	D001716	Bird Fancier's Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:13891	bird fancier's lung	skos:exactMatch	umls	C0005592	Bird Fancier's Lung	manually_reviewed	orcid:0000-0003-4423-4370
@@ -2898,18 +2685,13 @@ doid	DOID:13957	uterine corpus lipoleiomyoma	skos:exactMatch	efo	1000614	Uterine
 doid	DOID:1432	blindness	skos:exactMatch	mesh	D001766	Blindness	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:14453	farmer's lung	skos:exactMatch	mesh	D005203	Farmer's Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:14453	farmer's lung	skos:exactMatch	umls	C0015634	Farmer's Lung	manually_reviewed	orcid:0000-0003-4423-4370
-doid	DOID:1470	major depressive disorder	skos:exactMatch	mesh	D003865	Depressive Disorder, Major	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:14749	methylmalonic acidemia	skos:exactMatch	mesh	C537358	Methylmalonic acidemia	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:14764	Larsen syndrome	skos:exactMatch	mesh	C580241	Larsen Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:1529	penile disease	skos:exactMatch	mesh	D010409	Penile Diseases	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1555	urticaria	skos:exactMatch	mesh	D014581	Urticaria	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1575	rheumatic disease	skos:exactMatch	mesh	D012216	Rheumatic Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:1673	pneumothorax	skos:exactMatch	mesh	D011030	Pneumothorax	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1788	peritoneal mesothelioma	skos:exactMatch	efo	1000467	Peritoneal Mesothelioma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1829	urethral stricture	skos:exactMatch	mesh	D014525	Urethral Stricture	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:1920	hyperuricemia	skos:exactMatch	efo	0009104	hyperuricemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2001	neuroma	skos:exactMatch	efo	0009619	neuroma	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:2123	tularemia	skos:exactMatch	mesh	D014406	Tularemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2176	carbuncle	skos:exactMatch	mesh	D002270	Carbuncle	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2626	choroid plexus papilloma	skos:exactMatch	efo	1000177	Choroid Plexus Papilloma	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:2708	mushroom workers' lung	skos:exactMatch	umls	C0155889	Mushroom Worker's Lung	manually_reviewed	orcid:0000-0003-4423-4370
@@ -2921,23 +2703,16 @@ doid	DOID:3907	lung squamous cell carcinoma	skos:exactMatch	umls	C0149782	Squamo
 doid	DOID:3908	lung non-small cell carcinoma	skos:exactMatch	umls	C0007131	Non-Small Cell Lung Carcinoma	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:3910	lung adenocarcinoma	skos:exactMatch	mesh	D000077192	Adenocarcinoma of Lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:3910	lung adenocarcinoma	skos:exactMatch	umls	C0152013	Adenocarcinoma of lung (disorder)	manually_reviewed	orcid:0000-0003-4423-4370
-doid	DOID:3965	Merkel cell carcinoma	skos:exactMatch	mesh	D015266	Carcinoma, Merkel Cell	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:4001	ovarian carcinoma	skos:exactMatch	umls	C0029925	Ovarian Carcinoma	manually_reviewed	orcid:0000-0003-4423-4370
-doid	DOID:4156	primary syphilis	skos:exactMatch	mesh	C536772	Syphilis, primary	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:417	autoimmune disease	skos:exactMatch	mesh	D001327	Autoimmune Diseases	manually_reviewed	orcid:0000-0001-9439-5346
-doid	DOID:4337	tinea capitis	skos:exactMatch	mesh	D014006	Tinea Capitis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:4492	avian influenza	skos:exactMatch	mesh	D005585	Influenza in Birds	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4492	avian influenza	skos:exactMatch	umls	C0016627	Influenza in Birds	manually_reviewed	orcid:0000-0003-4423-4370
-doid	DOID:4500	hypokalemia	skos:exactMatch	mesh	D007008	Hypokalemia	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:4556	lung large cell carcinoma	skos:exactMatch	umls	C0345958	Large cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4829	adenosquamous lung carcinoma	skos:exactMatch	umls	C0279557	Adenosquamous cell lung cancer	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:4872	lung adenoid cystic carcinoma	skos:exactMatch	umls	C1334439	adenoid cystic carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:490	hemangioma of lung	skos:exactMatch	umls	C0241983	hemangioma of lung	manually_reviewed	orcid:0000-0003-4423-4370
-doid	DOID:507	adjustment disorder	skos:exactMatch	mesh	D000275	Adjustment Disorders	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:5136	lung leiomyoma	skos:exactMatch	umls	C1334447	Leiomyoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:5199	ureteral obstruction	skos:exactMatch	mesh	D014517	Ureteral Obstruction	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:5265	lung leiomyosarcoma	skos:exactMatch	umls	C1334448	leiomyosarcoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
-doid	DOID:528	hydrarthrosis	skos:exactMatch	mesh	D006833	Hydrarthrosis	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:5386	lung adenoma	skos:exactMatch	umls	C0345964	Adenoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:5409	lung small cell carcinoma	skos:exactMatch	umls	C0149925	Small cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:5583	lung giant cell carcinoma	skos:exactMatch	umls	C0345960	Giant cell carcinoma of lung	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2521,6 +2521,7 @@ doid	0090048	dystonia 16	skos:exactMatch	mesh	C567430	Dystonia 16	manually_revie
 doid	0090056	dystonia 12	skos:exactMatch	mesh	C538001	Dystonia 12	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0090058	torsion dystonia with onset in infancy	skos:exactMatch	mesh	C536969	Torsion dystonia with onset in infancy	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0090066	Fanconi-like syndrome	skos:exactMatch	mesh	C536855	Fanconi like syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0090130	cortical dysplasia-focal epilepsy syndrome	skos:exactMatch	mesh	C567657	Cortical Dysplasia-Focal Epilepsy Syndrome	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0110006	3-methylglutaconic aciduria type 4	skos:exactMatch	mesh	C565393	3-Methylglutaconic Aciduria Type IV	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0110007	achromatopsia 2	skos:exactMatch	mesh	C536128	Achromatopsia 2	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0110008	achromatopsia 3	skos:exactMatch	mesh	C536129	Achromatopsia 3	manually_reviewed	orcid:0000-0001-9439-5346
@@ -2544,6 +2545,105 @@ doid	0110135	Bardet-Biedl syndrome 13	skos:exactMatch	mesh	C567140	Bardet-Biedl 
 doid	0110136	Bardet-Biedl syndrome 14	skos:exactMatch	mesh	C567141	Bardet-Biedl Syndrome 14	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0110188	Leber congenital amaurosis 14	skos:exactMatch	mesh	C567636	Leber Congenital Amaurosis 14	manually_reviewed	orcid:0000-0001-9439-5346
 doid	0110214	cleft soft palate	skos:exactMatch	mesh	C562950	Cleft Soft Palate	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110215	Leber congenital amaurosis 5	skos:exactMatch	mesh	C536602	Amaurosis congenita of Leber, type 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110216	Leber congenital amaurosis 11	skos:exactMatch	mesh	C564140	Leber Congenital Amaurosis 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110219	Brugada syndrome 2	skos:exactMatch	mesh	C567087	Brugada Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110220	Brugada syndrome 3	skos:exactMatch	mesh	C567509	Brugada Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110221	Brugada syndrome 4	skos:exactMatch	mesh	C567508	Brugada Syndrome 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110222	Brugada syndrome 5	skos:exactMatch	mesh	C567556	Brugada Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110223	Brugada syndrome 6	skos:exactMatch	mesh	C567735	Brugada Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110224	Brugada syndrome 7	skos:exactMatch	mesh	C567734	Brugada Syndrome 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110225	Brugada syndrome 8	skos:exactMatch	mesh	C567732	Brugada Syndrome 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110291	Leber congenital amaurosis 10	skos:exactMatch	mesh	C565720	Leber Congenital Amaurosis 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110329	Leber congenital amaurosis 6	skos:exactMatch	mesh	C565327	Leber Congenital Amaurosis 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110330	Leber congenital amaurosis 13	skos:exactMatch	mesh	C567197	Leber Congenital Amaurosis 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110331	Leber congenital amaurosis 3	skos:exactMatch	mesh	C565814	Leber Congenital Amaurosis 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110332	Leber congenital amaurosis 4	skos:exactMatch	mesh	C565778	Leber Congenital Amaurosis 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110337	osteogenesis imperfecta type 7	skos:exactMatch	mesh	C565200	Osteogenesis Imperfecta Type VII	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110353	retinitis pigmentosa 20	skos:exactMatch	mesh	C566718	Retinitis Pigmentosa 20	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110354	retinitis pigmentosa 19	skos:exactMatch	mesh	C566637	Retinitis Pigmentosa 19	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110355	retinitis pigmentosa 32	skos:exactMatch	mesh	C563689	Retinitis Pigmentosa 32	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110356	retinitis pigmentosa 18	skos:exactMatch	mesh	C563320	Retinitis Pigmentosa 18	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110357	retinitis pigmentosa 35	skos:exactMatch	mesh	C565206	Retinitis Pigmentosa 35	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110358	retinitis pigmentosa 12	skos:exactMatch	mesh	C563999	Retinitis Pigmentosa 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110366	retinitis pigmentosa 33	skos:exactMatch	mesh	C563676	Retinitis Pigmentosa 33	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110368	retinitis pigmentosa 26	skos:exactMatch	mesh	C564249	Retinitis Pigmentosa 26	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110376	retinitis pigmentosa 41	skos:exactMatch	mesh	C567422	Retinitis Pigmentosa 41	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110378	retinitis pigmentosa 29	skos:exactMatch	mesh	C567403	Retinitis Pigmentosa 29	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110381	retinitis pigmentosa 14	skos:exactMatch	mesh	C563992	Retinitis Pigmentosa 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110383	retinitis pigmentosa 7	skos:exactMatch	mesh	C564284	Retinitis Pigmentosa 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110384	retinitis pigmentosa 25	skos:exactMatch	mesh	C566425	Retinitis Pigmentosa 25	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110386	retinitis pigmentosa 42	skos:exactMatch	mesh	C567854	Retinitis Pigmentosa 42	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110387	retinitis pigmentosa 9	skos:exactMatch	mesh	C566716	Retinitis Pigmentosa 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110388	retinitis pigmentosa 10	skos:exactMatch	mesh	C566715	Retinitis Pigmentosa 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110391	retinitis pigmentosa 31	skos:exactMatch	mesh	C563685	Retinitis Pigmentosa 31	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110397	retinitis pigmentosa 27	skos:exactMatch	mesh	C563526	Retinitis Pigmentosa 27	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110399	retinitis pigmentosa 37	skos:exactMatch	mesh	C567005	Retinitis Pigmentosa 37	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110403	retinitis pigmentosa 13	skos:exactMatch	mesh	C564008	Retinitis Pigmentosa 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110404	retinitis pigmentosa 17	skos:exactMatch	mesh	C563437	Retinitis Pigmentosa 17	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110405	retinitis pigmentosa 36	skos:exactMatch	mesh	C566431	Retinitis Pigmentosa 36	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110406	retinitis pigmentosa 30	skos:exactMatch	mesh	C564310	Retinitis Pigmentosa 30	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110408	retinitis pigmentosa 11	skos:exactMatch	mesh	C563991	Retinitis Pigmentosa 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110409	retinitis pigmentosa 46	skos:exactMatch	mesh	C567249	Retinitis Pigmentosa 46	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110413	retinitis pigmentosa 6	skos:exactMatch	mesh	C564065	Retinitis Pigmentosa 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110414	retinitis pigmentosa 3	skos:exactMatch	mesh	C564520	Retinitis Pigmentosa 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110415	retinitis pigmentosa 2	skos:exactMatch	mesh	C567523	Retinitis Pigmentosa 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110417	retinitis pigmentosa 34	skos:exactMatch	mesh	C564475	Retinitis Pigmentosa 34	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110630	Wolfram syndrome 2	skos:exactMatch	mesh	C565733	Wolfram Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110645	long QT syndrome 2	skos:exactMatch	mesh	C563614	Long Qt Syndrome 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110646	long QT syndrome 3	skos:exactMatch	mesh	C565840	Long Qt Syndrome 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110647	long QT syndrome 5	skos:exactMatch	mesh	C566766	Long Qt Syndrome 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110648	long QT syndrome 6	skos:exactMatch	mesh	C566333	Long Qt Syndrome 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110650	long QT syndrome 9	skos:exactMatch	mesh	C567515	Long Qt Syndrome 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110651	long QT syndrome 10	skos:exactMatch	mesh	C567514	Long Qt Syndrome 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110652	long QT syndrome 11	skos:exactMatch	mesh	C567513	Long Qt Syndrome 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110653	long QT syndrome 12	skos:exactMatch	mesh	C567842	Long Qt Syndrome 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110702	hypotrichosis 5	skos:exactMatch	mesh	C567554	Hypotrichosis 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110736	neurodegeneration with brain iron accumulation 2b	skos:exactMatch	mesh	C565699	NBIA2B	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110872	holoprosencephaly 2	skos:exactMatch	mesh	C563579	Holoprosencephaly 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110873	holoprosencephaly 9	skos:exactMatch	mesh	C563659	Holoprosencephaly 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110874	holoprosencephaly 6	skos:exactMatch	mesh	C565274	Holoprosencephaly 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110875	holoprosencephaly 3	skos:exactMatch	mesh	C564181	Holoprosencephaly 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110876	holoprosencephaly 7	skos:exactMatch	mesh	C563660	Holoprosencephaly 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110878	holoprosencephaly 5	skos:exactMatch	mesh	C566464	Holoprosencephaly 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110879	holoprosencephaly 8	skos:exactMatch	mesh	C563723	Holoprosencephaly 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110880	holoprosencephaly 4	skos:exactMatch	mesh	C564180	Holoprosencephaly 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110882	inflammatory bowel disease 7	skos:exactMatch	mesh	C565353	Inflammatory Bowel Disease 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110883	inflammatory bowel disease 17	skos:exactMatch	mesh	C567378	Inflammatory Bowel Disease 17	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110884	inflammatory bowel disease 23	skos:exactMatch	mesh	C567326	Inflammatory Bowel Disease 23	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110885	inflammatory bowel disease 10	skos:exactMatch	mesh	C567021	Inflammatory Bowel Disease 10	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110886	inflammatory bowel disease 9	skos:exactMatch	mesh	C563926	Inflammatory Bowel Disease 9	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110887	inflammatory bowel disease 12	skos:exactMatch	mesh	C567388	Inflammatory Bowel Disease 12	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110888	inflammatory bowel disease 18	skos:exactMatch	mesh	C567377	Inflammatory Bowel Disease 18	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110889	inflammatory bowel disease 5	skos:exactMatch	mesh	C565234	Inflammatory Bowel Disease 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110890	inflammatory bowel disease 19	skos:exactMatch	mesh	C567372	Inflammatory Bowel Disease 19	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110891	inflammatory bowel disease 3	skos:exactMatch	mesh	C565764	Inflammatory Bowel Disease 3	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110893	inflammatory bowel disease 13	skos:exactMatch	mesh	C567384	Inflammatory Bowel Disease 13	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110894	inflammatory bowel disease 11	skos:exactMatch	mesh	C567154	Inflammatory Bowel Disease 11	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110895	inflammatory bowel disease 14	skos:exactMatch	mesh	C567383	Inflammatory Bowel Disease 14	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110896	inflammatory bowel disease 16	skos:exactMatch	mesh	C567380	Inflammatory Bowel Disease 16	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110897	inflammatory bowel disease 15	skos:exactMatch	mesh	C567381	Inflammatory Bowel Disease 15	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110898	inflammatory bowel disease 20	skos:exactMatch	mesh	C567361	Inflammatory Bowel Disease 20	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110900	inflammatory bowel disease 2	skos:exactMatch	mesh	C563310	Inflammatory Bowel Disease 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110901	inflammatory bowel disease 26	skos:exactMatch	mesh	C567217	Inflammatory Bowel Disease 26	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110902	inflammatory bowel disease 27	skos:exactMatch	mesh	C567559	Inflammatory Bowel Disease 27	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110903	inflammatory bowel disease 4	skos:exactMatch	mesh	C564680	Inflammatory Bowel Disease 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110904	inflammatory bowel disease 8	skos:exactMatch	mesh	C564682	Inflammatory Bowel Disease 8	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110905	inflammatory bowel disease 22	skos:exactMatch	mesh	C567327	Inflammatory Bowel Disease 22	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110906	inflammatory bowel disease 21	skos:exactMatch	mesh	C567338	Inflammatory Bowel Disease 21	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110907	inflammatory bowel disease 6	skos:exactMatch	mesh	C564681	Inflammatory Bowel Disease 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110908	inflammatory bowel disease 24	skos:exactMatch	mesh	C567252	Inflammatory Bowel Disease 24	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110912	leukocyte adhesion deficiency 3	skos:exactMatch	mesh	C567555	Leukocyte Adhesion Deficiency, Type III	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110926	nemaline myopathy 1	skos:exactMatch	mesh	C538348	Nemaline myopathy 1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110928	nemaline myopathy 2	skos:exactMatch	mesh	C538349	Nemaline Myopathy 2	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110932	nemaline myopathy 4	skos:exactMatch	mesh	C538351	Nemaline myopathy 4	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110934	nemaline myopathy 7	skos:exactMatch	mesh	C565198	Nemaline Myopathy 7	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110935	nemaline myopathy 6	skos:exactMatch	mesh	C538398	Nemaline myopathy 6	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110936	nemaline myopathy 5	skos:exactMatch	mesh	C538397	Nemaline myopathy 5	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110947	Waardenburg syndrome type 2B	skos:exactMatch	mesh	C536465	Waardenburg syndrome type 2B	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110950	Waardenburg syndrome type 2A	skos:exactMatch	mesh	C536464	Waardenburg syndrome type 2A	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110964	brachydactyly type A1	skos:exactMatch	mesh	C537088	Brachydactyly type A1	manually_reviewed	orcid:0000-0001-9439-5346
+doid	0110966	brachydactyly type A3	skos:exactMatch	mesh	C537090	Brachydactyly type A3	manually_reviewed	orcid:0000-0001-9439-5346
 doid	DOID:0040002	aspirin allergy	skos:exactMatch	umls	C0004058	Allergy to aspirin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040004	amoxicillin allergy	skos:exactMatch	umls	C0571417	Allergy to amoxicillin	manually_reviewed	orcid:0000-0003-4423-4370
 doid	DOID:0040005	ceftriaxone allergy	skos:exactMatch	umls	C0571463	Allergy to ceftriaxone	manually_reviewed	orcid:0000-0003-4423-4370


### PR DESCRIPTION
This PR does the following:
- Add new DOID-MESH predictions based on a new script that predicts largely correct, one-to-one mappings
- Curates these new mappings to find 152 new correct mappings
- Adds a script to add _all_ non-redundant, curated DOID-MESH mappings (i.e., not just new ones but also ones that were curated earlier) to the editable OWL version of DOID in version control

Note that some, relatively less reliable predictions originally produced by https://github.com/biopragmatics/biomappings/blob/master/scripts/generate_doid_mappings.py were removed, though these do contain at least some correct predictions, though in principle, this new script would have found the same matches if they were non-redundant and one-to-one. 