### PR TITLE
Add UBERON-BTO predictions

### DIFF
--- a/scripts/generate_uberon_bto_mappings.py
+++ b/scripts/generate_uberon_bto_mappings.py
@@ -1,10 +1,9 @@
 """Generate mappings using Gilda from UBERON to BTO."""
 
 import gilda
-import obonet
 from gilda import Term, make_grounder
 from gilda.process import normalize
-
+import obonet
 
 from biomappings.resources import PredictionTuple, append_prediction_tuples
 
@@ -14,10 +13,11 @@ bto_graph = obonet.read_obo("/Users/ben/src/BTO/bto.obo")
 
 terms = []
 for node, data in bto_graph.nodes(data=True):
-    prefix, id_stub = node.split(':', maxsplit=1)
+    prefix, id_stub = node.split(":", maxsplit=1)
     identifier = node
-    term = Term(normalize(data['name']), data['name'],
-                prefix, identifier, data['name'], 'name', 'bto')
+    term = Term(
+        normalize(data["name"]), data["name"], prefix, identifier, data["name"], "name", "bto"
+    )
     terms.append(term)
 
 grounder = make_grounder(terms)

--- a/scripts/generate_uberon_bto_mappings.py
+++ b/scripts/generate_uberon_bto_mappings.py
@@ -1,9 +1,8 @@
 """Generate mappings using Gilda from UBERON to BTO."""
 
-import gilda
+import obonet
 from gilda import Term, make_grounder
 from gilda.process import normalize
-import obonet
 
 from biomappings.resources import PredictionTuple, append_prediction_tuples
 

--- a/scripts/generate_uberon_bto_mappings.py
+++ b/scripts/generate_uberon_bto_mappings.py
@@ -1,0 +1,54 @@
+"""Generate mappings using Gilda from UBERON to BTO."""
+
+import gilda
+import obonet
+from gilda import Term, make_grounder
+from gilda.process import normalize
+
+
+from biomappings.resources import PredictionTuple, append_prediction_tuples
+
+uberon_graph = obonet.read_obo("/Users/ben/src/uberon/src/ontology/uberon-edit.obo")
+bto_graph = obonet.read_obo("/Users/ben/src/BTO/bto.obo")
+
+
+terms = []
+for node, data in bto_graph.nodes(data=True):
+    prefix, id_stub = node.split(':', maxsplit=1)
+    identifier = node
+    term = Term(normalize(data['name']), data['name'],
+                prefix, identifier, data['name'], 'name', 'bto')
+    terms.append(term)
+
+grounder = make_grounder(terms)
+
+mappings = {}
+for node, data in uberon_graph.nodes(data=True):
+    if not node.startswith("UBERON"):
+        continue
+    bto_refs = [xref for xref in data.get("xref", []) if xref.startswith("BTO")]
+    if bto_refs:
+        continue
+    matches = grounder.ground(data["name"])
+    if matches and matches[0].term.db == "BTO":
+        mappings[node] = matches[0].term.id
+
+print("Found %d UBERON->BTO mappings." % len(mappings))
+
+predictions = []
+for uberon_id, bto_id in mappings.items():
+    pred = PredictionTuple(
+        source_prefix="uberon",
+        source_id=uberon_id,
+        source_name=uberon_graph.nodes[uberon_id]["name"],
+        relation="skos:exactMatch",
+        target_prefix="bto",
+        target_identifier=bto_id,
+        target_name=bto_graph.nodes[bto_id]["name"],
+        type="semapv:LexicalMatching",
+        confidence=0.9,
+        source="generate_uberon_bto_mappings.py",
+    )
+    predictions.append(pred)
+
+append_prediction_tuples(predictions, deduplicate=True, sort=True)

--- a/scripts/generate_uberon_bto_mappings.py
+++ b/scripts/generate_uberon_bto_mappings.py
@@ -6,9 +6,10 @@ from gilda.process import normalize
 
 from biomappings.resources import PredictionTuple, append_prediction_tuples
 
-uberon_graph = obonet.read_obo("/Users/ben/src/uberon/src/ontology/uberon-edit.obo")
-bto_graph = obonet.read_obo("/Users/ben/src/BTO/bto.obo")
-
+base = "/Users/ben/src"
+# base = "/Users/cthoyt/dev"
+uberon_graph = obonet.read_obo(f"{base}/uberon/src/ontology/uberon-edit.obo")
+bto_graph = obonet.read_obo(f"{base}/BTO/bto.obo")
 
 terms = []
 for node, data in bto_graph.nodes(data=True):
@@ -30,9 +31,9 @@ for node, data in uberon_graph.nodes(data=True):
     bto_used |= set(bto_refs)
     if bto_refs:
         continue
-    matches = grounder.ground(data["name"])
-    if matches and matches[0].term.db == "BTO":
-        mappings[node] = matches[0].term.id
+    for match in grounder.ground(data["name"]):
+        if match.term.db == "BTO":
+            mappings[node] = match.term.id
 
 print("Found %d existing UBERON->BTO mappings." % len(bto_used))
 print("Predicted %d new UBERON->BTO mappings." % len(mappings))

--- a/scripts/generate_uberon_bto_mappings.py
+++ b/scripts/generate_uberon_bto_mappings.py
@@ -23,20 +23,25 @@ for node, data in bto_graph.nodes(data=True):
 grounder = make_grounder(terms)
 
 mappings = {}
+bto_used = set()
 for node, data in uberon_graph.nodes(data=True):
     if not node.startswith("UBERON"):
         continue
     bto_refs = [xref for xref in data.get("xref", []) if xref.startswith("BTO")]
+    bto_used |= set(bto_refs)
     if bto_refs:
         continue
     matches = grounder.ground(data["name"])
     if matches and matches[0].term.db == "BTO":
         mappings[node] = matches[0].term.id
 
-print("Found %d UBERON->BTO mappings." % len(mappings))
+print("Found %d existing UBERON->BTO mappings." % len(bto_used))
+print("Predicted %d new UBERON->BTO mappings." % len(mappings))
 
 predictions = []
 for uberon_id, bto_id in mappings.items():
+    if bto_id in bto_used:
+        continue
     pred = PredictionTuple(
         source_prefix="uberon",
         source_id=uberon_id,

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -8992,6 +8992,7 @@ uberon	UBERON:0000127	facial nucleus	skos:exactMatch	mesh	D065828	Facial Nucleus
 uberon	UBERON:0000159	anal canal	skos:exactMatch	mesh	D001003	Anal Canal	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0000175	pleural effusion	skos:exactMatch	mesh	D010996	Pleural Effusion	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0000220	atlanto-occipital joint	skos:exactMatch	mesh	D001269	Atlanto-Occipital Joint	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
+uberon	UBERON:0000353	parenchyma	skos:exactMatch	bto	BTO:0001539	parenchyma	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	semapv:LexicalMatching	generate_uberon_bto_mappings.py	0.9
 uberon	UBERON:0000387	meniscus	skos:exactMatch	mesh	D000072600	Meniscus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0000569	ileocecal valve	skos:exactMatch	mesh	D007080	Ileocecal Valve	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0000939	imaginal disc	skos:exactMatch	mesh	D060227	Imaginal Discs	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
@@ -9012,6 +9013,7 @@ uberon	UBERON:0001863	scala vestibuli	skos:exactMatch	mesh	D054738	Scala Vestibu
 uberon	UBERON:0001883	olfactory tubercle	skos:exactMatch	mesh	D066208	Olfactory Tubercle	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0001907	zona incerta	skos:exactMatch	mesh	D065820	Zona Incerta	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0001944	pretectal region	skos:exactMatch	mesh	D066250	Pretectal Region	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
+uberon	UBERON:0001947	red nucleus	skos:exactMatch	bto	BTO:0006329	red nucleus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	semapv:LexicalMatching	generate_uberon_bto_mappings.py	0.9
 uberon	UBERON:0001977	blood serum	skos:exactMatch	mesh	D044967	Serum	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0001995	fibrocartilage	skos:exactMatch	mesh	D051445	Fibrocartilage	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			
 uberon	UBERON:0002020	gray matter	skos:exactMatch	mesh	D066128	Gray Matter	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346			


### PR DESCRIPTION
Addresses #128. This PR adds a script to generate simple UBERON-BTO mappings that are at the level of exact or approximate lexical matches using standard names. As far as I can tell, BTO doesn't maintain its own cross-references to UBERON, however, UBERON already maps to 1403 BTO IDs which we don't redundantly predict here. The script predicts 60 missing mappings. If useful, it could be extended to take synonyms into account in addition to standard names.