### PR TITLE
Use preferred prefixes in SSSOM

### DIFF
--- a/docs/_data/sssom/biomappings.sssom.yml
+++ b/docs/_data/sssom/biomappings.sssom.yml
@@ -7,79 +7,79 @@ creator_id:
 - orcid:0000-0003-1307-2508
 - orcid:0000-0003-4423-4370
 curie_map:
+  AGRO: http://purl.obolibrary.org/obo/AGRO_
+  APOLLO_SV: http://purl.obolibrary.org/obo/APOLLO_SV_
+  BFO: http://purl.obolibrary.org/obo/BFO_
+  BTO: http://purl.obolibrary.org/obo/BTO_
+  CARO: http://purl.obolibrary.org/obo/CARO_
+  CHEBI: http://purl.obolibrary.org/obo/CHEBI_
+  CHMO: http://purl.obolibrary.org/obo/CHMO_
+  CIDO: http://purl.obolibrary.org/obo/CIDO_
+  CL: http://purl.obolibrary.org/obo/CL_
+  CLO: http://purl.obolibrary.org/obo/CLO_
+  DOID: http://purl.obolibrary.org/obo/DOID_
+  DRON: http://purl.obolibrary.org/obo/DRON_
+  DeBiO: https://biopragmatics.github.io/debio/
+  EFO: http://www.ebi.ac.uk/efo/EFO_
+  ENVO: http://purl.obolibrary.org/obo/ENVO_
+  FMA: http://purl.org/sig/ont/fma/fma
+  GO: http://purl.obolibrary.org/obo/GO_
+  HP: http://purl.obolibrary.org/obo/HP_
+  IAO: http://purl.obolibrary.org/obo/IAO_
+  IDO: http://purl.obolibrary.org/obo/IDO_
+  IDOMAL: http://purl.obolibrary.org/obo/IDOMAL_
+  MAXO: http://purl.obolibrary.org/obo/MAXO_
+  MI: http://purl.obolibrary.org/obo/MI_
+  MIAPA: http://purl.obolibrary.org/obo/MIAPA_
+  MIRO: http://purl.obolibrary.org/obo/MIRO_
+  MONDO: http://purl.obolibrary.org/obo/MONDO_
+  MPATH: http://purl.obolibrary.org/obo/MPATH_
+  NBO: http://purl.obolibrary.org/obo/NBO_
+  NCBIProtein: https://www.ncbi.nlm.nih.gov/protein/
+  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+  NCIT: http://purl.obolibrary.org/obo/NCIT_
+  OAE: http://purl.obolibrary.org/obo/OAE_
+  OBI: http://purl.obolibrary.org/obo/OBI_
+  OGG: http://purl.obolibrary.org/obo/OGG_
+  OGMS: http://purl.obolibrary.org/obo/OGMS_
+  OPMI: http://purl.obolibrary.org/obo/OPMI_
+  PATO: http://purl.obolibrary.org/obo/PATO_
+  PCO: http://purl.obolibrary.org/obo/PCO_
+  PR: http://purl.obolibrary.org/obo/PR_
   RO: http://purl.obolibrary.org/obo/RO_
-  agro: http://purl.obolibrary.org/obo/AGRO_
+  STATO: http://purl.obolibrary.org/obo/STATO_
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  VO: http://purl.obolibrary.org/obo/VO_
   agrovoc: http://aims.fao.org/aos/agrovoc/c_
   aio: https://w3id.org/aio/
-  apollosv: http://purl.obolibrary.org/obo/APOLLO_SV_
-  bfo: http://purl.obolibrary.org/obo/BFO_
-  bto: https://www.brenda-enzymes.org/ontology.php?ontology_id=3&id_go=
-  caro: http://purl.obolibrary.org/obo/CARO_
   ccle: https://www.cbioportal.org/patient?studyId=ccle_broad_2019&caseId=
   cellosaurus: https://www.cellosaurus.org/CVCL_
   cemo: https://biopragmatics.github.io/providers/cemo/
-  chebi: 'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:'
-  chmo: http://purl.obolibrary.org/obo/CHMO_
-  cido: http://purl.obolibrary.org/obo/CIDO_
-  cl: https://www.ebi.ac.uk/ols/ontologies/cl/terms?iri=http://purl.obolibrary.org/obo/
-  clo: https://www.ebi.ac.uk/ols4/ontologies/clo/terms?short_form=CLO_
   commoncoreontology: http://www.ontologyrepository.com/CommonCoreOntologies/
   cpt: https://www.aapc.com/codes/cpt-codes/
   cvx: https://biopragmatics.github.io/providers/cvx/
   dc: http://purl.org/dc/elements/1.1/
-  debio: https://biopragmatics.github.io/debio/
   depmap: https://depmap.org/portal/cell_line/
-  doid: 'https://www.ebi.ac.uk/ols4/ontologies/doid/terms?obo_id=DOID:'
-  dron: http://purl.obolibrary.org/obo/DRON_
-  efo: http://www.ebi.ac.uk/efo/EFO_
-  envo: http://purl.obolibrary.org/obo/ENVO_
-  fma: http://purl.org/sig/ont/fma/fma
   fplx: https://sorgerlab.github.io/famplex/
-  go: 'http://amigo.geneontology.org/amigo/term/GO:'
   hgnc: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/
-  hp: 'https://hpo.jax.org/app/browse/term/HP:'
-  iao: http://purl.obolibrary.org/obo/IAO_
-  ido: 'https://www.ebi.ac.uk/ols4/ontologies/ido/terms?obo_id=IDO:'
   idocovid19: http://purl.obolibrary.org/obo/COVIDO_
-  idomal: http://purl.obolibrary.org/obo/IDOMAL_
-  interpro: https://www.ebi.ac.uk/interpro/entry/
+  interpro: http://purl.obolibrary.org/obo/IPR_
   ito: https://bioportal.bioontology.org/ontologies/ITO/?p=classes&conceptid=https://identifiers.org/ito:ITO_
   kegg.pathway: https://www.kegg.jp/entry/
   kestrelo: http://purl.obolibrary.org/obo/kestrelo_
-  maxo: http://purl.obolibrary.org/obo/MAXO_
   mesh: https://meshb.nlm.nih.gov/record/ui?ui=
-  mi: 'https://www.ebi.ac.uk/ols4/ontologies/mi/terms?obo_id=MI:'
-  miapa: http://purl.obolibrary.org/obo/MIAPA_
-  miro: http://purl.obolibrary.org/obo/MIRO_
-  mondo: http://purl.obolibrary.org/obo/MONDO_
-  mpath: http://purl.obolibrary.org/obo/MPATH_
-  nbo: http://purl.obolibrary.org/obo/NBO_
-  ncbiprotein: https://www.ncbi.nlm.nih.gov/protein/
-  ncbitaxon: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=
-  ncit: http://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI%20Thesaurus&code=
   ndfrt: https://evs.nci.nih.gov/ftp1/NDF-RT/NDF-RT.owl#
-  oae: http://purl.obolibrary.org/obo/OAE_
-  obi: http://purl.obolibrary.org/obo/OBI_
   obo: http://purl.obolibrary.org/obo/
-  oboinowl: http://www.geneontology.org/formats/oboInOwl#
-  ogg: http://purl.obolibrary.org/obo/OGG_
-  ogms: http://purl.obolibrary.org/obo/OGMS_
-  opmi: http://purl.obolibrary.org/obo/OPMI_
+  oboInOwl: http://www.geneontology.org/formats/oboInOwl#
   orcid: https://orcid.org/
-  pato: http://purl.obolibrary.org/obo/PATO_
-  pco: http://purl.obolibrary.org/obo/PCO_
   pfam: https://www.ebi.ac.uk/interpro/entry/pfam/
-  pr: 'https://proconsortium.org/app/entry/PR:'
   pubchem.compound: https://pubchem.ncbi.nlm.nih.gov/compound/
   reactome: https://reactome.org/content/detail/
   skos: http://www.w3.org/2004/02/skos/core#
-  stato: http://purl.obolibrary.org/obo/STATO_
-  uberon: 'https://www.ebi.ac.uk/ols4/ontologies/uberon/terms?obo_id=UBERON:'
   umls: http://linkedlifedata.com/resource/umls/id/
   uniprot: https://purl.uniprot.org/uniprot/
   uniprot.chain: http://purl.uniprot.org/annotation/
   vido: http://purl.obolibrary.org/obo/VIDO_
-  vo: http://purl.obolibrary.org/obo/VO_
   vsmo: http://purl.obolibrary.org/obo/VSMO_
   wikipathways: http://www.wikipathways.org/instance/
 license: https://creativecommons.org/publicdomain/zero/1.0/

--- a/src/biomappings/export_sssom.py
+++ b/src/biomappings/export_sssom.py
@@ -72,11 +72,15 @@ def get_sssom_df(use_tqdm: bool = False):
 
             rows.append(
                 (
-                    get_curie(mapping["source prefix"], mapping["source identifier"]),
+                    get_curie(
+                        mapping["source prefix"], mapping["source identifier"], preferred=True
+                    ),
                     mapping["source name"],
                     f'{mapping["relation"]}',
                     predicate_modifier,
-                    get_curie(mapping["target prefix"], mapping["target identifier"]),
+                    get_curie(
+                        mapping["target prefix"], mapping["target identifier"], preferred=True
+                    ),
                     mapping["target name"],
                     mapping["type"],  # match justification
                     source,  # curator CURIE
@@ -96,11 +100,11 @@ def get_sssom_df(use_tqdm: bool = False):
         prefixes.add(mapping["target prefix"])
         rows.append(
             (
-                get_curie(mapping["source prefix"], mapping["source identifier"]),
+                get_curie(mapping["source prefix"], mapping["source identifier"], preferred=True),
                 mapping["source name"],
                 f'{mapping["relation"]}',
                 "",  # no predicate modifier
-                get_curie(mapping["target prefix"], mapping["target identifier"]),
+                get_curie(mapping["target prefix"], mapping["target identifier"], preferred=True),
                 mapping["target name"],
                 mapping["type"],  # match justification
                 None,  # no curator CURIE
@@ -125,7 +129,8 @@ def sssom():
         uri_prefix = bioregistry.get_uri_prefix(prefix)
         if uri_prefix is None:
             raise ValueError(f"could not look up URI prefix for {prefix}")
-        prefix_map[prefix] = uri_prefix
+        pp = bioregistry.get_preferred_prefix(prefix) or prefix
+        prefix_map[pp] = uri_prefix
 
     with open(META_PATH, "w") as file:
         yaml.safe_dump({"curie_map": prefix_map, "creator_id": creators, **META}, file)

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -231,11 +231,13 @@ def check_valid_prefix_id(prefix: str, identifier: str):
         raise InvalidIdentifierPattern(prefix, identifier, pattern)
 
 
-def get_curie(prefix: str, identifier: str) -> str:
+def get_curie(prefix: str, identifier: str, *, preferred: bool = False) -> str:
     """Get a normalized curie from a pre-parsed prefix/identifier pair."""
     prefix_norm, identifier_norm = bioregistry.normalize_parsed_curie(prefix, identifier)
     if prefix_norm is None or identifier_norm is None:
         raise ValueError(f"could not normalize {prefix}:{identifier}")
+    if preferred:
+        prefix_norm = bioregistry.get_preferred_prefix(prefix_norm) or prefix_norm
     return f"{prefix_norm}:{identifier_norm}"
 
 


### PR DESCRIPTION
As a follow-up to https://github.com/biopragmatics/biomappings/issues/154, this PR aligns the SSSOM export with OBO prefixes/URI prefixes. CC @gouttegd.

Built on top of https://github.com/biopragmatics/bioregistry/pull/939.