### PR TITLE
Curate CVX mismatches

### DIFF
--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -1590,3 +1590,6 @@ wikipathways	WP890	Osteoclast	debio:0000003	mesh	D010010	Osteoclasts	semapv:Manu
 wikipathways	WP914	NLR Proteins	debio:0000003	mesh	D000070576	NLR Proteins	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
 wikipathways	WP942	Matrix Metalloproteinases	debio:0000003	fplx	MMP	MMP	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
 wikipathways	WP956	Osteoblast	debio:0000003	mesh	D010006	Osteoblasts	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370			
+cvx	90	rabies vaccine, unspecified formulation	skos:exactMatch	vo	0006021	Human Rabies vaccine from human diploid cell culture	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370
+cvx	33	pneumococcal polysaccharide vaccine, 23 valent	skos:exactMatch	mesh	D022242	Pneumococcal Vaccines	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370
+cvx	180	tetanus immune globulin	skos:exactMatch	vo	0005452	tetanus immune globulin	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370


### PR DESCRIPTION
some CVX terms are obsoleted / replaced by other terms. This PR adds explicit negative mappings to make sure they aren't used