### PR TITLE
Add inverted ChEBI-MeSH mappings

### DIFF
--- a/src/biomappings/resources/positive.sssom.tsv
+++ b/src/biomappings/resources/positive.sssom.tsv
@@ -2534,6 +2534,7 @@ chebi:18219	ammonium hydroxide	skos:exactMatch	mesh:D064753	Ammonium Hydroxide	s
 chebi:19544	2-dehydroecdysone	skos:exactMatch	mesh:C054761	2-dehydroecdysone	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
 chebi:19813	24-methylenecycloartenol	skos:exactMatch	mesh:C405143	24-methylenecycloartenol	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
 chebi:20506	5,6,7,8-tetrahydrofolic acid	skos:exactMatch	mesh:C030371	5,6,7,8-tetrahydrofolic acid	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+chebi:205835	Axinelline A	skos:exactMatch	mesh:C000593051	axinelline A	semapv:MappingInversion	orcid:0000-0001-9439-5346		
 chebi:20607	5-methylcytidine	skos:exactMatch	mesh:C016568	5-methylcytidine	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
 chebi:207229	dihydroartemisinin	skos:exactMatch	mesh:C039060	dihydroartemisinin	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
 chebi:22333	alkylating agent	skos:exactMatch	mesh:D000477	Alkylating Agents	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
@@ -5113,6 +5114,7 @@ mesh:C063638	lobucavir	skos:exactMatch	ncit:C82253	Lobucavir	semapv:ManualMappin
 mesh:C065655	anti-inhibitor coagulant complex	skos:exactMatch	ncit:C90853	Anti-Inhibitor Coagulant Complex	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	https://github.com/biomappings/biomappings/blob/a80ed2/scripts/import_gilda_mappings.py	
 mesh:C066100	poliovirus receptor	skos:exactMatch	ncit:C118556	Poliovirus Receptor	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
 mesh:C067419	CBL protein, human	skos:exactMatch	uniprot:P22681	CBL	semapv:ManualMappingCuration	orcid:0000-0003-1307-2508		
+mesh:C067604	visnadinn	skos:exactMatch	chebi:10001	Visnadi	semapv:MappingInversion	orcid:0000-0001-9439-5346		2026-05-02
 mesh:C070699	FGFBP1 protein, human	skos:exactMatch	uniprot:Q14512	FGFBP1	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
 mesh:C074558	STX2 protein, human	skos:exactMatch	uniprot:P32856	STX2	semapv:ManualMappingCuration	orcid:0000-0003-1307-2508		
 mesh:C074856	FKBP3 protein, human	skos:exactMatch	uniprot:Q00688	FKBP3	semapv:ManualMappingCuration	orcid:0000-0003-1307-2508		


### PR DESCRIPTION
This acts as a smoke test to make sure any consumers of Biomappings handle inverted mappings