### PR TITLE
Add lexical embedding predictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.6,<1.0"]
+requires = ["uv_build>=0.12.6,<1.0"]
 build-backend = "uv_build"
 
 [project]
@@ -59,8 +59,8 @@ dependencies = [
     "tqdm",
     "curies>=0.15.0",
     "bioregistry>=0.14.0",
-    "sssom-pydantic>=0.6.1",
-    "sssom-curator[predict-lexical,web]>=0.6.1",
+    "sssom-pydantic>=0.6.3",
+    "sssom-curator[predict-lexical,web]>=0.6.2",
 ]
 
 # see https://peps.python.org/pep-0735/ and https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups
@@ -105,8 +105,8 @@ bump = [
     "bump-my-version",
 ]
 build = [
-    "uv>=0.9.6",
-    "uv-build>=0.9.6",
+    "uv>=0.12.6",
+    "uv-build>=0.12.6",
 ]
 release = [
     { include-group = "build" },

--- a/src/biomappings/resources/positive.sssom.tsv
+++ b/src/biomappings/resources/positive.sssom.tsv
@@ -50,7 +50,7 @@
 #  fbcv: http://purl.obolibrary.org/obo/FBcv_
 #  fideo: http://purl.obolibrary.org/obo/FIDEO_
 #  fix: http://purl.obolibrary.org/obo/FIX_
-#  fma: 'https://www.ebi.ac.uk/ols4/ontologies/fma/terms?obo_id=FMA:'
+#  fma: http://purl.org/sig/ont/fma/
 #  fplx: https://sorgerlab.github.io/famplex/
 #  genepio: http://purl.obolibrary.org/obo/GENEPIO_
 #  go: http://purl.obolibrary.org/obo/GO_
@@ -11570,6 +11570,7 @@ mondo:0007547	epidermoid cysts	skos:exactMatch	mesh:D004814	Epidermal Cyst	semap
 mondo:0007578	esterase B	skos:exactMatch	mesh:C049262	esterase B	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346				
 mondo:0007608	desmoid tumor	skos:exactMatch	mesh:D018222	Fibromatosis, Aggressive	semapv:ManualMappingCuration	orcid:0000-0002-1216-4761			generate_mondo_mesh_mappings.py	
 mondo:0007614	congenital fibrosis of extraocular muscles	skos:exactMatch	mesh:C580012	Congenital Fibrosis of the Extraocular Muscles	semapv:ManualMappingCuration	orcid:0000-0002-1216-4761			generate_mondo_mesh_mappings.py	
+mondo:0007758	epidermolytic palmoplantar keratoderma, 1	skos:narrowMatch	mesh:D053546	Keratoderma, Palmoplantar, Epidermolytic	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370				2026-08-26
 mondo:0007767	hyperparathyroidism 1	skos:exactMatch	mesh:C564166	Hyperparathyroidism 1	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370				
 mondo:0007794	hypogonadotropic hypogonadism 7 with or without anosmia	skos:exactMatch	mesh:C562785	Idiopathic Hypogonadotropic Hypogonadism	semapv:ManualMappingCuration	orcid:0000-0002-1216-4761			generate_mondo_mesh_mappings.py	
 mondo:0007817	IgE responsiveness, atopic	skos:exactMatch	mesh:C564133	Ige Responsiveness, Atopic	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346				


### PR DESCRIPTION
This PR bumps the versions of sssom-pydantic and sssom-curator to use the new lexical embedding similarity workflow, then applies it with a high cutoff between mondo and mesh to add about 50 (new) predictions. Most of them are wrong since they capture places where mondo goes more in detail than mesh